### PR TITLE
NI-298 Add Trunk for Linting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,17 @@
 env:
+  ENG_BK_AGENT: eng-default
   STAGE_BK_AGENT: rokt-stage-us-west-2-intel-linux-build-large
 
 steps:
+  - name: ":kotlin::broom: Trunk code check"
+    key: "trunk-code-check"
+    plugins:
+      - ssh://git@github.com/ROKT/trunk-buildkite-plugin.git#stable:
+          team: "new-integrations"
+    agents:
+      queue: ${ENG_BK_AGENT}
+    timeout_in_minutes: 15
+
   - label: ":android: :gradle: Assemble debug"
     key: "build-uxhelper-debug"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,10 +4,8 @@ env:
 
 steps:
   - name: ":kotlin::broom: Trunk code check"
-    key: "trunk-code-check"
     plugins:
       - ssh://git@github.com/ROKT/trunk-buildkite-plugin.git#stable:
-          team: "new-integrations"
     agents:
       queue: ${ENG_BK_AGENT}
     timeout_in_minutes: 15

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# https://editorconfig.org/
+# This configuration is used by ktlint when spotless invokes it
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+# don't set end_of_line; let correct git setting checkout the appropriate one for OS
+charset = utf-8
+
+[*.{json,yml,yaml,html,tf}]
+indent_size = 2
+ij_json_array_wrapping = normal
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+max_line_length = 120
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+
+[*Test.{kt,kts}]
+ktlint_standard_max-line-length = disabled
+

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends: markdownlint/style/prettier

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -38,6 +38,7 @@ lint:
     - trufflehog@3.83.1
   disabled:
     - yamllint
+    - osv-scanner
   ignore:
     - linters: [ALL]
       paths:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,14 +2,13 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.7
+  version: 1.22.8-beta.4
   sha256:
-    darwin_arm64: 0f43b0d758ee0ad405816e58abffa6fa5716ffec579515202d11302473465d3d
-    darwin_x86_64: d73bb6a468fb453fe86eb019fb88cfcce4e211f3d36948eeedad9cd01025daf2
-    linux_arm64: 7fe43f01194c36ab8de751c29b17eb6064ba38be9ce65c66e47bda1e2bed1a0e
-    linux_x86_64: 2a917fee7c40786422bbbd108d2d4588315494d536825f4e4dd3f41c71399aa2
-    mingw_x86_64: 2cdfe81bb893df592e36f5e2cc63b8168a86202df2f77c23e80b32307e6a15a2
-    windows_x86_64: 0cbf2db62ac29b8346e7321f6135a95c9afd9386e8f01db998a95fbd43b3f604
+    darwin_arm64: 633286b0bb4c6e3928fab62bd7ed32e803521e79ebd569bacf797037b50c3921
+    darwin_x86_64: 04124669516c544ab6a63bb70553420a17bcab889ef848a3e115d9ee9f1f02ab
+    linux_arm64: 7dc71994419f2ad145a04089643ff155c60517d46a700e67c9867fad89b625df
+    linux_x86_64: 9ca744e050160a191b7dbce0e1cc29772201c5476b728f8224d56f4221173fc5
+    mingw_x86_64: e1fd255ec92e2fd23fe48ddc7186013e26c9d5e686742abdadc9d1f0b2feadb3
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,49 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.22.7
+  sha256:
+    darwin_arm64: 0f43b0d758ee0ad405816e58abffa6fa5716ffec579515202d11302473465d3d
+    darwin_x86_64: d73bb6a468fb453fe86eb019fb88cfcce4e211f3d36948eeedad9cd01025daf2
+    linux_arm64: 7fe43f01194c36ab8de751c29b17eb6064ba38be9ce65c66e47bda1e2bed1a0e
+    linux_x86_64: 2a917fee7c40786422bbbd108d2d4588315494d536825f4e4dd3f41c71399aa2
+    mingw_x86_64: 2cdfe81bb893df592e36f5e2cc63b8168a86202df2f77c23e80b32307e6a15a2
+    windows_x86_64: 0cbf2db62ac29b8346e7321f6135a95c9afd9386e8f01db998a95fbd43b3f604
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.6.4
+      uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+    - go@1.21.0
+    - java@13.0.11
+    - node@18.12.1
+    - python@3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - checkov@3.2.276
+    - git-diff-check
+    - ktlint@1.4.0
+    - markdownlint@0.42.0
+    - oxipng@9.1.2
+    - prettier@3.3.3
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
+    - taplo@0.9.3
+    - trufflehog@3.83.1
+  disabled:
+    - yamllint
+  ignore:
+    - linters: [ALL]
+      paths:
+        - gradlew
+actions:
+  enabled:
+    - trunk-check-pre-push-always
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,13 +2,13 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.8-beta.4
+  version: 1.22.8
   sha256:
-    darwin_arm64: 633286b0bb4c6e3928fab62bd7ed32e803521e79ebd569bacf797037b50c3921
-    darwin_x86_64: 04124669516c544ab6a63bb70553420a17bcab889ef848a3e115d9ee9f1f02ab
-    linux_arm64: 7dc71994419f2ad145a04089643ff155c60517d46a700e67c9867fad89b625df
-    linux_x86_64: 9ca744e050160a191b7dbce0e1cc29772201c5476b728f8224d56f4221173fc5
-    mingw_x86_64: e1fd255ec92e2fd23fe48ddc7186013e26c9d5e686742abdadc9d1f0b2feadb3
+    darwin_arm64: aa5721bac03ea4e244cfe71f41a12a4a1cbf36746bfae1bc125a13a26d8d1a59
+    darwin_x86_64: 9ad94bf53fd6f0232cc89ff744477251e7f33634c77326a7b710770fa91344aa
+    linux_arm64: 67c66c5f616fc6b36a41ea3c673a30587555ea0674fab34b54afb66fe2932420
+    linux_x86_64: c02184f82905221f52a3bb43ec2ba9acb554d2727e69919d352a2386c49213e9
+    mingw_x86_64: 84725a1e85f2fdc1500b7de5c75af9d2642c4947d429c66de862da001fe3cd0b
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
@@ -25,7 +25,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - checkov@3.2.276
+    - checkov@3.2.278
     - git-diff-check
     - ktlint@1.4.0
     - markdownlint@0.42.0
@@ -34,7 +34,7 @@ lint:
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - taplo@0.9.3
-    - trufflehog@3.83.1
+    - trufflehog@3.83.2
   disabled:
     - yamllint
     - osv-scanner


### PR DESCRIPTION
### Background

We want to add linting pre-commit/push and to the CI pipeline. This PR adds Trunk to the project as well as the trunk plugin to the Buildkite pipeline.

Fixes [NI-298](https://rokt.atlassian.net/browse/NI-298)

### What Has Changed

- Added trunk with cli version 1.22.8

### How Has This Been Tested?

Trunk step in the CI pipeline passes

### Notes

There are some lint issues, will address them in a future PR.
~There is an issue with the current stable version of trunk, the beta version has been recommended as a fix~
Stable version has been released

### Checklist

-   [x] I have performed a self-review of my own code.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.
-   [x] I have verified that CI completes successfully.
-   [x] All insignificant commits have been squashed.
