### PR TITLE
NI-336 Add Test Tags for Automated Tests

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
@@ -2,6 +2,9 @@ package com.rokt.roktux.component.button
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.rokt.modelmapper.hmap.get
+import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_IS_POSITIVE
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.roktux.component.ComposableComponent
 import com.rokt.roktux.component.LayoutUiModelFactory
@@ -29,7 +32,16 @@ internal class CreativeResponseComponent(
                 model = model,
                 factory = factory,
                 modifierFactory = modifierFactory,
-                modifier = modifier,
+                modifier = modifier
+                    .testTag(
+                        if (responseOptionModel.properties.get<Boolean>(KEY_IS_POSITIVE) ==
+                            true
+                        ) {
+                            "positive_button"
+                        } else {
+                            "negative_button"
+                        },
+                    ),
                 offerState = offerState,
                 isDarkModeEnabled = isDarkModeEnabled,
                 breakpointIndex = breakpointIndex,

--- a/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
@@ -1,11 +1,15 @@
 package com.rokt.roktux.component.button
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import com.rokt.modelmapper.hmap.get
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_IS_POSITIVE
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
+import com.rokt.roktux.BuildConfig
 import com.rokt.roktux.component.ComposableComponent
 import com.rokt.roktux.component.LayoutUiModelFactory
 import com.rokt.roktux.component.ModifierFactory
@@ -17,6 +21,7 @@ internal class CreativeResponseComponent(
     private val modifierFactory: ModifierFactory,
 ) : ComposableComponent<LayoutSchemaUiModel.CreativeResponseUiModel> {
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     override fun Render(
         model: LayoutSchemaUiModel.CreativeResponseUiModel,
@@ -33,6 +38,7 @@ internal class CreativeResponseComponent(
                 factory = factory,
                 modifierFactory = modifierFactory,
                 modifier = modifier
+                    .semantics { testTagsAsResourceId = BuildConfig.DEBUG }
                     .testTag(
                         if (responseOptionModel.properties.get<Boolean>(KEY_IS_POSITIVE) ==
                             true

--- a/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/CreativeResponseComponent.kt
@@ -43,9 +43,9 @@ internal class CreativeResponseComponent(
                         if (responseOptionModel.properties.get<Boolean>(KEY_IS_POSITIVE) ==
                             true
                         ) {
-                            "positive_button"
+                            POSITIVE_BUTTON_TEST_TAG
                         } else {
-                            "negative_button"
+                            NEGATIVE_BUTTON_TEST_TAG
                         },
                     ),
                 offerState = offerState,
@@ -62,5 +62,10 @@ internal class CreativeResponseComponent(
                 )
             }
         }
+    }
+
+    companion object {
+        private const val POSITIVE_BUTTON_TEST_TAG = "positive_button"
+        private const val NEGATIVE_BUTTON_TEST_TAG = "negative_button"
     }
 }


### PR DESCRIPTION
### Background

Our automated tests require the resource id to be set on the creative response buttons in order for them to be recognised by the framework. This adds the required ids to the creative response button when the build config is Debug.

Fixes [NI-336](https://rokt.atlassian.net/browse/NI-336)

### What Has Changed

- Added test tags and represent them as resource ids for creative response button.

### How Has This Been Tested?

Verified via Appium:
![image](https://github.com/user-attachments/assets/a4e78ef5-6692-4a64-a141-d13add56a1be)

### Checklist

-   [x] I have performed a self-review of my own code.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.
-   [x] I have verified that CI completes successfully.
-   [x] All insignificant commits have been squashed.
