### PR TITLE
NI-356 Send Final Events from Events Queue After Job is Cancelled

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -68,9 +69,11 @@ internal class LayoutViewModel(
         // It queues the request in a chunk of 25ms and max buffer as 20 and sends
         // them together.
         viewModelScope.launch(Dispatchers.IO) {
-            _eventsQueue.chunk(EVENT_REQUEST_BUFFER_MILLIS, QUEUE_CAPACITY).collect { events ->
-                events.distinct().filterNot { _sentEvents.contains(it) }.takeIf { it.isNotEmpty() }?.let {
-                    processEventQueue(it)
+            withContext(NonCancellable) {
+                _eventsQueue.chunk(EVENT_REQUEST_BUFFER_MILLIS, QUEUE_CAPACITY).collect { events ->
+                    events.distinct().filterNot { _sentEvents.contains(it) }.takeIf { it.isNotEmpty() }?.let {
+                        processEventQueue(it)
+                    }
                 }
             }
         }

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -79,7 +80,9 @@ internal class LayoutViewModel(
                 // This processes the final batch of events before the job is finally cancelled
                 _eventsQueue.replayCache.distinct().filterNot { _sentEvents.contains(it) }.takeIf { it.isNotEmpty() }
                     ?.let {
-                        processEventQueue(it)
+                        withContext(NonCancellable) {
+                            processEventQueue(it)
+                        }
                     }
             }
         }


### PR DESCRIPTION
### Background

Since the LayoutVM is bound to the lifecycle of the composable, it's possible that the composable exits the composition and the VM is cleared before the event queue is fully processed. This change uses the replay cache on the events queue and sends the events after the coroutine is cancelled. It is similar to the docs [here](https://kotlinlang.org/docs/cancellation-and-timeouts.html#run-non-cancellable-block)

This mostly affects embedded layouts as modal layouts typically have enough time for the events to be sent during the exit animation before the composable is removed.

Fixes [NI-356](https://rokt.atlassian.net/browse/NI-356)

### What Has Changed

- Cache the last 5 events in the events queue and send them if required when the vm is cleared and the coroutine to handle events is cancelled.

### How Has This Been Tested?

Verified via e2e tests

### Checklist

-   [x] I have performed a self-review of my own code.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.
-   [x] I have verified that CI completes successfully.
-   [x] All insignificant commits have been squashed.
