### PR TITLE
NI-375 Fix Negative Button and Scrolling Behaviour

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/CarouselDistributionComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CarouselDistributionComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -43,6 +44,7 @@ internal class CarouselDistributionComponent(
         onEventSent: (LayoutContract.LayoutEvent) -> Unit,
     ) {
         val pagerState = rememberPagerState { offerState.lastOfferIndex + 1 }
+        var canScroll by remember { mutableStateOf(true) }
         val coroutineScope = rememberCoroutineScope()
         var viewWidth by remember { mutableIntStateOf(0) }
         val viewableItems = getViewableItems(
@@ -68,8 +70,10 @@ internal class CarouselDistributionComponent(
         LaunchedEffect(key1 = offerState.targetOfferIndex) {
             coroutineScope.launch {
                 if (offerState.targetOfferIndex != (pagerState.currentPage)) {
+                    canScroll = false
                     pagerState.animateScrollToPage(offerState.targetOfferIndex)
                     onEventSent(LayoutContract.LayoutEvent.SetCurrentOffer(offerState.targetOfferIndex))
+                    canScroll = true
                 }
             }
         }
@@ -104,6 +108,7 @@ internal class CarouselDistributionComponent(
                 state = pagerState,
                 pagerSnapDistance = PagerSnapDistance.atMost(viewableItems),
             ),
+            userScrollEnabled = canScroll,
         ) { page ->
             factory.CreateComposable(
                 model = LayoutSchemaUiModel.MarketingUiModel(),
@@ -159,7 +164,6 @@ private fun getPeekThroughDimension(
 }
 
 private fun carouselPageSize(viewableItems: Int) = object : PageSize {
-    override fun Density.calculateMainAxisPageSize(availableSpace: Int, pageSpacing: Int): Int {
-        return availableSpace / viewableItems
-    }
+    override fun Density.calculateMainAxisPageSize(availableSpace: Int, pageSpacing: Int): Int =
+        availableSpace / viewableItems
 }

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -328,7 +328,12 @@ internal class LayoutViewModel(
             if (newOfferIndex in FIRST_OFFER_INDEX..currentUiState.offerUiState.lastOfferIndex) {
                 currentOffer = newOfferIndex
                 handleNextOfferLoaded(currentOffer)
-                currentUiState.copy(offerUiState = currentUiState.offerUiState.copy(currentOfferIndex = currentOffer))
+                currentUiState.copy(
+                    offerUiState = currentUiState.offerUiState.copy(
+                        currentOfferIndex = currentOffer,
+                        targetOfferIndex = currentOffer,
+                    ),
+                )
             } else {
                 if (pluginModel.settings.closeOnComplete) {
                     uxEvent(RoktUxEvent.LayoutCompleted(pluginId))


### PR DESCRIPTION
### Background

When selecting the negative CTA then swiping back to the previous page, the negative button will no longer progress the carousel. This is because the target offer does not get updated correctly.

When tapping the negative CTA twice quickly, the scroll behaviour is stopped mid-animation and the carousel remains on the same page.

This PR aims to amend both of these issues.

Fixes [NI-375](https://rokt.atlassian.net/browse/NI-375)

### What Has Changed

- Update target offer when progressing via negative cta tap to keep it consistent
- Disable user scrolling while animating to the next offer to prevent the animation from being interrupted and the offer progression not being updated correctly.

### How Has This Been Tested?

Both behaviours:
https://github.com/user-attachments/assets/b579d0bb-a032-4d65-b687-5874cc2a7f1b

### Checklist

-   [x] I have performed a self-review of my own code.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.
-   [x] I have verified that CI completes successfully.
-   [x] All insignificant commits have been squashed.
