### PR TITLE
LAYOUT-1770 - Add ViewState caching support

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -73,7 +73,7 @@ fun RoktLayout(
     val context = LocalContext.current
     val imageLoader = roktUxConfig.imageHandlingStrategy.getImageLoader(context)
     var currentOffer by rememberSaveable(key = experienceHash) {
-        mutableIntStateOf(FIRST_OFFER_INDEX)
+        roktUxConfig.viewState?.offerIndex?.let { mutableIntStateOf(it) } ?: mutableIntStateOf(FIRST_OFFER_INDEX)
     }
     var customState by rememberSaveable(
         key = experienceHash,
@@ -86,9 +86,13 @@ fun RoktLayout(
             },
         ),
     ) {
-        mutableStateOf(mapOf<String, Int>())
+        roktUxConfig.viewState?.customStates?.let { mutableStateOf(it) } ?: mutableStateOf(mapOf())
     }
-    if (LocalViewModelStoreOwner.current != null) {
+    val offerCustomStates by remember {
+        roktUxConfig.viewState?.offerCustomStates?.let { mutableStateOf(it) }
+            ?: mutableStateOf(mapOf())
+    }
+    if (LocalViewModelStoreOwner.current != null && roktUxConfig.viewState?.pluginDismissed != true) {
         WithComposableScopedViewModelStoreOwner(key = experienceHash) {
             val viewModel = viewModel<DIComponentViewModel>(
                 factory = DIComponentViewModel.DIComponentViewModelFactory(
@@ -105,9 +109,13 @@ fun RoktLayout(
                             ),
                         )
                     },
+                    viewStateChange = { state ->
+                        roktUxConfig.viewStateChange?.invoke(state)
+                    },
                     imageLoader = imageLoader,
                     currentOffer = currentOffer,
-                    customState = customState,
+                    customStates = customState,
+                    offerCustomStates = offerCustomStates,
                     handleUrlByApp = roktUxConfig.handleUrlByApp,
                 ),
             )

--- a/roktux/src/main/java/com/rokt/roktux/RoktLayoutView.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayoutView.kt
@@ -70,6 +70,8 @@ class RoktLayoutView @JvmOverloads constructor(
                     composeFontMap(composeFontMap)
                     roktUxConfig?.imageHandlingStrategy?.let { imageHandlingStrategy(it) }
                     roktUxConfig?.colorMode?.let { colorMode(it) }
+                    roktUxConfig?.viewState?.let { viewState(it) }
+                    roktUxConfig?.viewStateChange?.let { viewStateChange(it) }
                 }.build()
             }
             RoktLayout(
@@ -132,10 +134,8 @@ class RoktLayoutView @JvmOverloads constructor(
     } ?: FontFamily.Default
 }
 
-private fun FontItemStyle.toFontStyle(): FontStyle {
-    return when (this) {
-        FontItemStyle.Normal -> FontStyle.Normal
-        FontItemStyle.Italic -> FontStyle.Italic
-        else -> FontStyle.Normal
-    }
+private fun FontItemStyle.toFontStyle(): FontStyle = when (this) {
+    FontItemStyle.Normal -> FontStyle.Normal
+    FontItemStyle.Italic -> FontStyle.Italic
+    else -> FontStyle.Normal
 }

--- a/roktux/src/main/java/com/rokt/roktux/RoktUxConfig.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktUxConfig.kt
@@ -19,6 +19,8 @@ class RoktUxConfig private constructor(
     val composeFontMap: Map<String, FontFamily>? = null,
     val imageHandlingStrategy: ImageHandlingStrategy,
     val colorMode: ColorMode,
+    val viewState: RoktViewState? = null,
+    val viewStateChange: ((RoktViewState) -> Unit)? = null,
     val handleUrlByApp: Boolean = true,
 ) {
     /**
@@ -35,6 +37,8 @@ class RoktUxConfig private constructor(
         private var imageHandlingStrategy: ImageHandlingStrategy = NetworkStrategy(),
         private var colorMode: ColorMode = ColorMode.SYSTEM,
         private var handleUrlByApp: Boolean = true,
+        private var viewState: RoktViewState? = null,
+        private var viewStateChange: ((RoktViewState) -> Unit)? = null,
     ) {
         /**
          * Sets the XML font family map.
@@ -73,6 +77,21 @@ class RoktUxConfig private constructor(
         fun colorMode(colorMode: ColorMode) = apply { this.colorMode = colorMode }
 
         /**
+         * Sets the view state.
+         *
+         * @param viewState The view state configuration to use in the UX.
+         */
+        fun viewState(viewState: RoktViewState) = apply { this.viewState = viewState }
+
+        /**
+         * Sets view state change callback.
+         *
+         * @param viewStateChange The callback to be called when the view state changes.
+         */
+        fun viewStateChange(viewStateChange: ((RoktViewState) -> Unit)?) =
+            apply { this.viewStateChange = viewStateChange }
+
+        /**
          * Builds the RoktUxConfig instance.
          *
          * @return The RoktUxConfig instance.
@@ -83,6 +102,8 @@ class RoktUxConfig private constructor(
             imageHandlingStrategy = imageHandlingStrategy,
             colorMode = colorMode,
             handleUrlByApp = handleUrlByApp,
+            viewState = viewState,
+            viewStateChange = viewStateChange,
         )
     }
 

--- a/roktux/src/main/java/com/rokt/roktux/RoktViewState.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktViewState.kt
@@ -1,0 +1,18 @@
+package com.rokt.roktux
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoktViewState(
+    @SerialName("pluginId")
+    val pluginId: String,
+    @SerialName("customStates")
+    val customStates: Map<String, Int>,
+    @SerialName("offerCustomStates")
+    val offerCustomStates: Map<String, Map<String, Int>>,
+    @SerialName("offerIndex")
+    val offerIndex: Int,
+    @SerialName("pluginDismissed")
+    val pluginDismissed: Boolean,
+)

--- a/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
@@ -35,7 +35,11 @@ internal class LayoutVariantMarketingComponent(private val factory: LayoutUiMode
     ) {
         val layoutComponent = LocalLayoutComponent.current
         val component: MarketingComponent = remember {
-            MarketingComponent(layoutComponent, offerState.currentOfferIndex, emptyMap())
+            MarketingComponent(
+                component = layoutComponent,
+                currentOffer = offerState.currentOfferIndex,
+                customStates = offerState.offerCustomStates[offerState.currentOfferIndex.toString()] ?: emptyMap(),
+            )
         }
         val viewModel = viewModel<MarketingViewModel>(
             factory = component[MarketingViewModel.MarketingViewModelFactory::class.java],

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
@@ -3,6 +3,7 @@ package com.rokt.roktux.di.layout
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.text.font.FontFamily
 import coil.ImageLoader
+import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.di.core.Component
 import com.rokt.roktux.event.RoktPlatformEvent
 import com.rokt.roktux.event.RoktUxEvent
@@ -13,10 +14,12 @@ internal class LayoutComponent(
     location: String,
     onUxEvent: (event: RoktUxEvent) -> Unit,
     onPlatformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
+    onViewStateChange: (state: RoktViewState) -> Unit,
     imageLoader: ImageLoader,
     handleUrlByApp: Boolean,
     currentOffer: Int,
-    customState: Map<String, Int>,
+    customStates: Map<String, Int>,
+    offerCustomStates: Map<String, Map<String, Int>>,
 ) : Component(
     listOf(
         LayoutModule(
@@ -24,10 +27,12 @@ internal class LayoutComponent(
             location,
             onUxEvent,
             onPlatformEvent,
+            onViewStateChange,
             imageLoader,
             handleUrlByApp,
             currentOffer,
-            customState,
+            customStates,
+            offerCustomStates,
         ),
     ),
 )

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
@@ -5,6 +5,7 @@ import com.rokt.modelmapper.data.DataBinding
 import com.rokt.modelmapper.data.DataBindingImpl
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl
 import com.rokt.modelmapper.mappers.ModelMapper
+import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.component.LayoutUiModelFactory
 import com.rokt.roktux.di.core.Module
 import com.rokt.roktux.di.core.get
@@ -19,10 +20,12 @@ internal class LayoutModule(
     private val location: String,
     private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
     private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
+    private val viewStateChange: (state: RoktViewState) -> Unit,
     private val imageLoader: ImageLoader,
     private val handleUrlByApp: Boolean,
     private val currentOffer: Int,
-    private val customState: Map<String, Int>,
+    private val customStates: Map<String, Int>,
+    private val offerCustomStates: Map<String, Map<String, Int>>,
 ) : Module() {
     init {
         this.bind<DataBinding, DataBindingImpl>()
@@ -40,12 +43,14 @@ internal class LayoutModule(
                 location = get(LOCATION),
                 uxEvent = uxEvent,
                 platformEvent = platformEvent,
+                viewStateChange = viewStateChange,
                 modelMapper = get(),
                 ioDispatcher = get(IO),
                 mainDispatcher = get(MAIN),
                 handleUrlByApp = handleUrlByApp,
                 currentOffer = currentOffer,
-                customState = customState,
+                customStates = customStates,
+                offerCustomStates = offerCustomStates,
             )
         }
         this.provideModuleScoped {

--- a/roktux/src/main/java/com/rokt/roktux/di/variants/marketing/MarketingComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/variants/marketing/MarketingComponent.kt
@@ -3,10 +3,10 @@ package com.rokt.roktux.di.variants.marketing
 import com.rokt.roktux.di.core.Component
 import com.rokt.roktux.di.layout.LayoutComponent
 
-internal class MarketingComponent(component: LayoutComponent, currentOffer: Int, customState: Map<String, Int>) :
+internal class MarketingComponent(component: LayoutComponent, currentOffer: Int, customStates: Map<String, Int>) :
     Component(
         listOf(
-            MarketingModule(currentOffer, customState),
+            MarketingModule(currentOffer, customStates),
         ),
         listOf(component),
     )

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import coil.ImageLoader
+import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.di.layout.LayoutComponent
 import com.rokt.roktux.event.RoktPlatformEvent
 import com.rokt.roktux.event.RoktUxEvent
@@ -13,9 +14,11 @@ internal class DIComponentViewModel(
     private val location: String,
     private val onUxEvent: (uxEvent: RoktUxEvent) -> Unit,
     private val onPlatformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
+    private val onViewStateChange: (state: RoktViewState) -> Unit,
     private val imageLoader: ImageLoader,
     private val currentOffer: Int,
-    private val customState: Map<String, Int>,
+    private val customStates: Map<String, Int>,
+    private val offerCustomStates: Map<String, Map<String, Int>>,
     private val handleUrlByApp: Boolean,
 ) : ViewModel() {
 
@@ -24,10 +27,12 @@ internal class DIComponentViewModel(
         location,
         onUxEvent,
         onPlatformEvent,
+        onViewStateChange,
         imageLoader,
         handleUrlByApp,
         currentOffer,
-        customState,
+        customStates,
+        offerCustomStates,
     )
 
     class DIComponentViewModelFactory(
@@ -35,9 +40,11 @@ internal class DIComponentViewModel(
         private val location: String,
         private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
         private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
+        private val viewStateChange: (state: RoktViewState) -> Unit,
         private val imageLoader: ImageLoader,
         private val currentOffer: Int,
-        private val customState: Map<String, Int>,
+        private val customStates: Map<String, Int>,
+        private val offerCustomStates: Map<String, Map<String, Int>>,
         private val handleUrlByApp: Boolean,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -48,9 +55,11 @@ internal class DIComponentViewModel(
                     location = location,
                     onUxEvent = uxEvent,
                     onPlatformEvent = platformEvent,
+                    onViewStateChange = viewStateChange,
                     imageLoader = imageLoader,
                     currentOffer = currentOffer,
-                    customState = customState,
+                    customStates = customStates,
+                    offerCustomStates = offerCustomStates,
                     handleUrlByApp = handleUrlByApp,
                 ) as T
             }

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
@@ -24,6 +24,7 @@ internal class LayoutContract {
         data class LayoutVariantSwiped(val currentOffer: Int) : LayoutEvent
         data class ViewableItemsChanged(val viewableItems: Int) : LayoutEvent
         data class SetCustomState(val key: String, val value: Int) : LayoutEvent
+        data class SetOfferCustomState(val offerId: Int, val customState: Map<String, Int>) : LayoutEvent
         data class LayoutVariantNavigated(val targetOffer: Int) : LayoutEvent
         data class SetCurrentOffer(val currentOffer: Int) : LayoutEvent
         data class SignalViewed(val offerId: Int) : LayoutEvent

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutUiState.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutUiState.kt
@@ -3,11 +3,9 @@ package com.rokt.roktux.viewmodel.layout
 import androidx.compose.runtime.Immutable
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 
-internal data class LayoutUiState(
-    val model: LayoutSchemaUiModel,
-    val offerUiState: OfferUiState,
-)
+internal data class LayoutUiState(val model: LayoutSchemaUiModel, val offerUiState: OfferUiState)
 
 @Immutable
 internal data class OfferUiState(
@@ -18,4 +16,6 @@ internal data class OfferUiState(
     val creativeCopy: ImmutableMap<String, String>,
     val breakpoints: ImmutableMap<String, Int>,
     val customState: ImmutableMap<String, Int>,
+    val offerCustomStates: ImmutableMap<String, ImmutableMap<String, Int>> =
+        emptyMap<String, ImmutableMap<String, Int>>().toImmutableMap(),
 )

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/variants/MarketingVariantViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/variants/MarketingVariantViewModel.kt
@@ -41,6 +41,14 @@ internal class MarketingViewModel(
 
             is LayoutContract.LayoutEvent.SetCustomState -> {
                 updateCustomState(event.key, event.value)
+                setEffect {
+                    MarketingVariantContract.LayoutVariantEffect.PropagateEvent(
+                        LayoutContract.LayoutEvent.SetOfferCustomState(
+                            currentOffer,
+                            customState,
+                        ),
+                    )
+                }
             }
 
             else -> {

--- a/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
@@ -57,14 +57,16 @@ class DcuiComponentRule(val composeTestRule: ComposeContentTestRule) : BaseCompo
         composeTestRule.setContent {
             CompositionLocalProvider(
                 LocalLayoutComponent provides LayoutComponent(
-                    "",
-                    "",
-                    {},
-                    {},
-                    NetworkStrategy().getImageLoader(LocalContext.current),
-                    true,
-                    0,
-                    mapOf(),
+                    experienceResponse = "",
+                    location = "",
+                    onUxEvent = {},
+                    onPlatformEvent = {},
+                    onViewStateChange = {},
+                    imageLoader = NetworkStrategy().getImageLoader(LocalContext.current),
+                    handleUrlByApp = true,
+                    currentOffer = 0,
+                    customStates = mapOf(),
+                    offerCustomStates = mapOf(),
                 ),
                 LocalFontFamilyProvider provides persistentMapOf("roboto" to FontFamily.Default),
             ) {
@@ -82,7 +84,8 @@ class DcuiComponentRule(val composeTestRule: ComposeContentTestRule) : BaseCompo
                             ),
                         ) ?: 1,
                         creativeCopy = dcuiNodeComponentState?.creativeCopy?.associateBy(
-                            { it.key }, { it.value },
+                            { it.key },
+                            { it.value },
                         )?.toImmutableMap() ?: persistentMapOf(),
                         breakpoints = breakpoints,
                         customState = persistentMapOf(),

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
@@ -53,7 +53,7 @@ class MarketingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `SetCustomState event should update the custom state`() = runTest {
+    fun `SetCustomState event should update the custom state and propagate the event`() = runTest {
         // Given
         val key = "key"
         val value = 1
@@ -61,10 +61,19 @@ class MarketingViewModelTest : BaseViewModelTest() {
         // When
         viewModel.setEvent(LayoutContract.LayoutEvent.SetCustomState(key, value))
         val viewState = viewModel.viewState.value
+        val effect = viewModel.effect.first()
 
         // Then
         val successState = viewState as BaseContract.BaseViewState.Success
         assertThat(successState.value.customState).containsEntry(key, value)
+        assertThat(effect).isInstanceOf(MarketingVariantContract.LayoutVariantEffect.PropagateEvent::class.java)
+        val propagateEvent = effect as MarketingVariantContract.LayoutVariantEffect.PropagateEvent
+        assertThat(propagateEvent.event).isEqualTo(
+            LayoutContract.LayoutEvent.SetOfferCustomState(
+                0,
+                mapOf(key to value),
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

* Add callback to send viewState to the host
* Receive viewState back and restore the view

Fixes [LAYOUT-1770](https://rokt.atlassian.net/browse/LAYOUT-1770)

### What Has Changed

Add ViewState caching support

### How Has This Been Tested?

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
