### PR TITLE
NOJIRA - Centralise logic for maven publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import java.util.Properties
 
 buildscript {
@@ -49,3 +51,45 @@ extra["ROKT_TAG_ID"] = getProperty("ROKT_TAG_ID", "defaultTagId")
 extra["ROKT_PUB_ID"] = getProperty("ROKT_PUB_ID", "defaultPubId")
 extra["ROKT_SECRET"] = getProperty("ROKT_SECRET", "defaultSecretId")
 extra["ROKT_CLIENT_UNIQUE_ID"] = getProperty("ROKT_CLIENT_UNIQUE_ID", "defaultClientId")
+
+configure(subprojects) {
+    pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        val libArtifactId = project.name
+        val libGroupId = findProperty("libGroupId")?.toString()
+        val libDescription = findProperty("libDescription")?.toString()
+
+        extensions.configure<MavenPublishBaseExtension> {
+            println("Configuring Maven publish for project ${project.name}")
+            publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+            coordinates(artifactId = libArtifactId, groupId = libGroupId, version = formattedVersion)
+            signAllPublications()
+
+            pom {
+                name.set(libArtifactId)
+                description.set(libDescription)
+                url.set("https://docs.rokt.com")
+                licenses {
+                    license {
+                        name.set("Copyright 2024 Rokt Pte Ltd")
+                        url.set("https://rokt.com/sdk-license-2-0/")
+                    }
+                }
+                developers {
+                    developer {
+                        organization {
+                            name.set("Rokt Pte Ltd")
+                            url.set("https://rokt.com")
+                        }
+                        name.set("Rokt")
+                        email.set("nativeappsdev@rokt.com")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/ROKT/rokt-ux-helper-android")
+                    connection.set("scm:git:git://github.com/ROKT/rokt-ux-helper-android.git")
+                    developerConnection.set("scm:git:https://github.com/ROKT/rokt-ux-helper-android.git")
+                }
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,8 +52,9 @@ extra["ROKT_PUB_ID"] = getProperty("ROKT_PUB_ID", "defaultPubId")
 extra["ROKT_SECRET"] = getProperty("ROKT_SECRET", "defaultSecretId")
 extra["ROKT_CLIENT_UNIQUE_ID"] = getProperty("ROKT_CLIENT_UNIQUE_ID", "defaultClientId")
 
+val mavenPublishPluginId = libs.plugins.maven.publish.get().pluginId
 configure(subprojects) {
-    pluginManager.withPlugin("com.vanniktech.maven.publish") {
+    pluginManager.withPlugin(mavenPublishPluginId) {
         val libArtifactId = project.name
         val libGroupId = findProperty("libGroupId")?.toString()
         val libDescription = findProperty("libDescription")?.toString()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ androidxNavigation = "2.8.0"
 androidxWindowManager = "1.0.0"
 androidXbrowser = "1.5.0"
 coil = "2.2.2"
-gradleMavenPublishPlugin = "0.30.0"
 junit4 = "4.13.2"
 junitParams = "1.1.1"
 kotlin = "1.8.21"
@@ -38,6 +37,7 @@ activity = "1.9.2"
 constraintlayout = "2.1.4"
 mavenPublish = "0.30.0"
 
+# This is the value used to specify the published version on Maven Central
 roktUxHelper = "0.1.0"
 
 [libraries]

--- a/modelmapper/build.gradle.kts
+++ b/modelmapper/build.gradle.kts
@@ -1,4 +1,8 @@
-import com.vanniktech.maven.publish.SonatypeHost
+buildscript {
+    // Used by the Maven Publish plugin to setup the details for Maven central in root build.gradle.kts
+    extra["libGroupId"] = "com.rokt"
+    extra["libDescription"] = "Rokt Model Mapper Library"
+}
 
 plugins {
     alias(libs.plugins.android.library)
@@ -6,44 +10,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish)
-}
-
-val libGroupId = "com.rokt"
-val libArtifactId = "modelmapper"
-val formattedVersion: String by project
-val libDescription = "Rokt Model Mapper Library"
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    coordinates(artifactId = libArtifactId, groupId = libGroupId, version = formattedVersion)
-    signAllPublications()
-
-    pom {
-        name.set(libArtifactId)
-        description.set(libDescription)
-        url.set("https://docs.rokt.com")
-        licenses {
-            license {
-                name.set("Copyright 2024 Rokt Pte Ltd")
-                url.set("https://rokt.com/sdk-license-2-0/")
-            }
-        }
-        developers {
-            developer {
-                organization {
-                    name.set("Rokt Pte Ltd")
-                    url.set("https://rokt.com")
-                }
-                name.set("Rokt")
-                email.set("nativeappsdev@rokt.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/ROKT/rokt-ux-helper-android")
-            connection.set("scm:git:git://github.com/ROKT/rokt-ux-helper-android.git")
-            developerConnection.set("scm:git:https://github.com/ROKT/rokt-ux-helper-android.git")
-        }
-    }
 }
 
 android {

--- a/roktux/build.gradle.kts
+++ b/roktux/build.gradle.kts
@@ -1,4 +1,8 @@
-import com.vanniktech.maven.publish.SonatypeHost
+buildscript {
+    // Used by the Maven Publish plugin to setup the details for Maven central in root build.gradle.kts
+    extra["libGroupId"] = "com.rokt"
+    extra["libDescription"] = "Rokt UX Helper Library"
+}
 
 plugins {
     alias(libs.plugins.android.library)
@@ -9,43 +13,7 @@ plugins {
     alias(libs.plugins.maven.publish)
 }
 
-val libGroupId = "com.rokt"
-val libArtifactId = "roktux"
 val formattedVersion: String by project
-val libDescription = "Rokt UX Helper Library"
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    coordinates(artifactId = libArtifactId, groupId = libGroupId, version = formattedVersion)
-    signAllPublications()
-
-    pom {
-        name.set(libArtifactId)
-        description.set(libDescription)
-        url.set("https://docs.rokt.com")
-        licenses {
-            license {
-                name.set("Copyright 2024 Rokt Pte Ltd")
-                url.set("https://rokt.com/sdk-license-2-0/")
-            }
-        }
-        developers {
-            developer {
-                organization {
-                    name.set("Rokt Pte Ltd")
-                    url.set("https://rokt.com")
-                }
-                name.set("Rokt")
-                email.set("nativeappsdev@rokt.com")
-            }
-        }
-        scm {
-            url.set("https://github.com/ROKT/rokt-ux-helper-android")
-            connection.set("scm:git:git://github.com/ROKT/rokt-ux-helper-android.git")
-            developerConnection.set("scm:git:https://github.com/ROKT/rokt-ux-helper-android.git")
-        }
-    }
-}
 
 android {
     namespace = "com.rokt.roktux"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Currently the publishing logic is duplicated across the `modelmapper` and `roktux` modules.

Fixes N/A

### What Has Changed

Moved the logic to the root build.gradle.kts

### How Has This Been Tested?

Tested locally using `./gradlew check publishMavenPublicationToMavenLocal`

#### Output
<img width="352" alt="Screenshot 2024-12-11 at 10 12 30 am" src="https://github.com/user-attachments/assets/7e5d2d98-9c29-4711-977b-a8f8a30c44c4">


#### Verified the `maven-metadata-local.xml`
**modelmapper**
<img width="529" alt="Screenshot 2024-12-11 at 10 12 36 am" src="https://github.com/user-attachments/assets/00add22b-6ad4-4fbf-87ec-c0dccaa90c64">

**roktux**
<img width="491" alt="Screenshot 2024-12-11 at 10 14 38 am" src="https://github.com/user-attachments/assets/47e6e781-3d7a-4578-adc3-21f06c68fc14">

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
