### PR TITLE
LAYOUT-1770 - Serialize DCUI JSON in the same string format

### DIFF
--- a/modelmapper/src/main/java/com/rokt/modelmapper/model/NetworkLayoutVariant.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/model/NetworkLayoutVariant.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
@@ -33,6 +34,7 @@ object NetworkLayoutSchemaSerializer : KSerializer<LayoutSchemaModel> {
     }
 
     override fun serialize(encoder: Encoder, value: LayoutSchemaModel) {
-        encoder.encodeSerializableValue(LayoutSchemaModel.serializer(), value)
+        val json = Json { ignoreUnknownKeys = true }
+        encoder.encodeString(json.encodeToString(value))
     }
 }

--- a/modelmapper/src/main/java/com/rokt/modelmapper/model/RootSchemaModelSerializer.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/model/RootSchemaModelSerializer.kt
@@ -36,6 +36,7 @@ object RootSchemaModelSerializer :
         encoder: Encoder,
         value: RootSchemaModel<LayoutSchemaModel, LayoutDisplayPreset, LayoutSettings>,
     ) {
-        encoder.encodeSerializableValue(strategy, value)
+        val json = Json { ignoreUnknownKeys = true }
+        encoder.encodeString(json.encodeToString(strategy, value))
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

When serialising back, encode in the same format as it was received

Fixes [LAYOUT-1770](https://rokt.atlassian.net/browse/LAYOUT-1770)

### What Has Changed

Serialization of the DCUI JSON field

### How Has This Been Tested?

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
