### PR TITLE
LAYOUT-1902 - Trigger SignalLoadComplete when layout load is completed

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -82,6 +82,9 @@ data class RoktPlatformEvent(
 }
 
 enum class EventType {
+    @SerialName("SignalLoadComplete")
+    SignalLoadComplete,
+
     @SerialName("SignalImpression")
     SignalImpression,
 

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -155,6 +155,13 @@ internal class LayoutViewModel(
 
             is LayoutContract.LayoutEvent.LayoutReady -> {
                 uxEvent(RoktUxEvent.LayoutReady(pluginId))
+                handlePlatformEvent(
+                    RoktPlatformEvent(
+                        eventType = EventType.SignalLoadComplete,
+                        sessionId = experienceModel.sessionId,
+                        parentGuid = pluginModel.instanceGuid,
+                    ),
+                )
             }
 
             is LayoutContract.LayoutEvent.LayoutInteractive -> {
@@ -252,7 +259,7 @@ internal class LayoutViewModel(
             RoktPlatformEvent(
                 eventType = EventType.SignalInitialize,
                 sessionId = experienceModel.sessionId,
-                parentGuid = experienceModel.placementContext.pageInstanceGuid,
+                parentGuid = pluginModel.instanceGuid,
             ),
         )
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Trigger SignalLoadComplete when layout load is completed

Fixes [LAYOUT-1902](https://rokt.atlassian.net/browse/LAYOUT-1902)

### What Has Changed

* Fix the `parentGuid` of layout's `SignalInitialize` and set it correctly as plugin's instanceGuid
* Trigger SignalLoadComplete when layout load is completed

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
