### PR TITLE
LAYOUT-1906 - Implement SignalImpression with correct metadata

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.flow.onEach
  * @param location The location identifier for the layout.
  * @param modifier The modifier to be applied to the layout.
  * @param roktUxConfig The configuration for the Rokt UX.
+ * @param startTimeStamp Optional - The start timestamp of the layout request.
  * @param onUxEvent Callback for UX events.
  * @param onPlatformEvent Callback for platform events.
  */
@@ -66,6 +67,7 @@ fun RoktLayout(
     location: String,
     modifier: Modifier = Modifier,
     roktUxConfig: RoktUxConfig,
+    startTimeStamp: Long = System.currentTimeMillis(),
     onUxEvent: (event: RoktUxEvent) -> Unit = { },
     onPlatformEvent: (platformEvents: RoktPlatformEventsWrapper) -> Unit = { },
 ) {
@@ -101,6 +103,7 @@ fun RoktLayout(
                     experienceResponse = experienceResponse,
                     location = location,
                     uxEvent = onUxEvent,
+                    startTimeStamp = startTimeStamp,
                     platformEvent = { events ->
                         onPlatformEvent(
                             RoktPlatformEventsWrapper(

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
@@ -12,6 +12,7 @@ import kotlinx.collections.immutable.ImmutableMap
 internal class LayoutComponent(
     experienceResponse: String,
     location: String,
+    startTimeStamp: Long,
     onUxEvent: (event: RoktUxEvent) -> Unit,
     onPlatformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
     onViewStateChange: (state: RoktViewState) -> Unit,
@@ -25,6 +26,7 @@ internal class LayoutComponent(
         LayoutModule(
             experienceResponse,
             location,
+            startTimeStamp,
             onUxEvent,
             onPlatformEvent,
             onViewStateChange,

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 internal class LayoutModule(
     private val experience: String,
     private val location: String,
+    private val startTimeStamp: Long,
     private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
     private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
     private val viewStateChange: (state: RoktViewState) -> Unit,
@@ -41,6 +42,7 @@ internal class LayoutModule(
         this.provideModuleScoped {
             LayoutViewModel.RoktViewModelFactory(
                 location = get(LOCATION),
+                startTimeStamp = startTimeStamp,
                 uxEvent = uxEvent,
                 platformEvent = platformEvent,
                 viewStateChange = viewStateChange,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
@@ -12,6 +12,7 @@ import com.rokt.roktux.event.RoktUxEvent
 internal class DIComponentViewModel(
     private val experienceResponse: String,
     private val location: String,
+    private val startTimeStamp: Long,
     private val onUxEvent: (uxEvent: RoktUxEvent) -> Unit,
     private val onPlatformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
     private val onViewStateChange: (state: RoktViewState) -> Unit,
@@ -25,6 +26,7 @@ internal class DIComponentViewModel(
     val component = LayoutComponent(
         experienceResponse,
         location,
+        startTimeStamp,
         onUxEvent,
         onPlatformEvent,
         onViewStateChange,
@@ -38,6 +40,7 @@ internal class DIComponentViewModel(
     class DIComponentViewModelFactory(
         private val experienceResponse: String,
         private val location: String,
+        private val startTimeStamp: Long,
         private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
         private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
         private val viewStateChange: (state: RoktViewState) -> Unit,
@@ -53,6 +56,7 @@ internal class DIComponentViewModel(
                 return DIComponentViewModel(
                     experienceResponse = experienceResponse,
                     location = location,
+                    startTimeStamp = startTimeStamp,
                     onUxEvent = uxEvent,
                     onPlatformEvent = platformEvent,
                     onViewStateChange = viewStateChange,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -20,6 +20,7 @@ import com.rokt.modelmapper.uimodel.PluginModel
 import com.rokt.modelmapper.uimodel.SignalType
 import com.rokt.modelmapper.utils.DEFAULT_VIEWABLE_ITEMS
 import com.rokt.modelmapper.utils.FIRST_OFFER_INDEX
+import com.rokt.modelmapper.utils.roktDateFormat
 import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.event.EventNameValue
 import com.rokt.roktux.event.EventType
@@ -39,11 +40,13 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Date
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 internal class LayoutViewModel(
     private val location: String,
+    private val startTimeStamp: Long,
     private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
     private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
     private val viewStateChange: (state: RoktViewState) -> Unit,
@@ -271,6 +274,14 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalImpression,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
+                metadata = listOf(
+                    EventNameValue(KEY_PAGE_SIGNAL_LOAD_START, roktDateFormat.format(Date(startTimeStamp))),
+                    EventNameValue(KEY_PAGE_RENDER_ENGINE, LAYOUTS_RENDER_ENGINE),
+                    EventNameValue(
+                        KEY_PAGE_SIGNAL_LOAD_COMPLETE,
+                        roktDateFormat.format(Date(System.currentTimeMillis())),
+                    ),
+                ),
             ),
         )
         handleNextOfferLoaded(FIRST_OFFER_INDEX)
@@ -516,6 +527,10 @@ internal class LayoutViewModel(
 
     companion object {
         private const val KEY_INITIATOR = "initiator"
+        private const val KEY_PAGE_RENDER_ENGINE = "pageRenderEngine"
+        private const val KEY_PAGE_SIGNAL_LOAD_START = "pageSignalLoadStart"
+        private const val KEY_PAGE_SIGNAL_LOAD_COMPLETE = "pageSignalLoadComplete"
+        private const val LAYOUTS_RENDER_ENGINE = "Layouts"
         private const val NO_MORE_OFFERS_TO_SHOW = "NO_MORE_OFFERS_TO_SHOW"
         private const val DISMISSED = "DISMISSED"
         private const val CLOSE_BUTTON = "CLOSE_BUTTON"
@@ -527,6 +542,7 @@ internal class LayoutViewModel(
 
     class RoktViewModelFactory(
         private val location: String,
+        private val startTimeStamp: Long,
         private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
         private val platformEvent: (platformEvents: List<RoktPlatformEvent>) -> Unit,
         private val viewStateChange: (state: RoktViewState) -> Unit,
@@ -543,6 +559,7 @@ internal class LayoutViewModel(
             if (modelClass.isAssignableFrom(LayoutViewModel::class.java)) {
                 return LayoutViewModel(
                     location = location,
+                    startTimeStamp = startTimeStamp,
                     uxEvent = uxEvent,
                     platformEvent = platformEvent,
                     viewStateChange = viewStateChange,

--- a/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
@@ -59,6 +59,7 @@ class DcuiComponentRule(val composeTestRule: ComposeContentTestRule) : BaseCompo
                 LocalLayoutComponent provides LayoutComponent(
                     experienceResponse = "",
                     location = "",
+                    startTimeStamp = System.currentTimeMillis(),
                     onUxEvent = {},
                     onPlatformEvent = {},
                     onViewStateChange = {},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

`SignalImpression` signal for layout need to have the correct metadata.

Fixes [LAYOUT-1906](https://rokt.atlassian.net/browse/LAYOUT-1906)

### What Has Changed

* Receive the start timestamp from the user(or default it to current timestamp)
* Include the  `pageSignalLoadStart`, `pageSignalLoadComplete` and `pageRenderEngine` metadata in `SignalImpression` event

### How Has This Been Tested?

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
