### PR TITLE
LAYOUT-1929 - Fix SignalInitialize duplicate issue

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -73,8 +73,16 @@ data class RoktPlatformEvent(
     @SerialName("pageInstanceGuid") val pageInstanceGuid: String = "",
     @SerialName("eventTime") val eventTime: String = roktDateFormat.format(Date()),
     @SerialName("eventData") val eventData: Map<String, String>? = null,
-    @SerialName("metadata") val metadata: List<EventNameValue> = emptyList(),
+    @SerialName("metadata") var metadata: List<EventNameValue> = emptyList(),
 ) : RoktEvent {
+    init {
+        val fixedMetadata = listOf(
+            EventNameValue(KEY_CAPTURE_METHOD, CLIENT_PROVIDED),
+            EventNameValue(KEY_CLIENT_TIMESTAMP, eventTime),
+        )
+        this.metadata += fixedMetadata
+    }
+
     fun toJsonString(): String {
         val json = Json { encodeDefaults = true }
         return json.encodeToString(this)
@@ -125,3 +133,7 @@ data class RoktPlatformEventsWrapper(
 ) {
     fun toJsonString(): String = Json { encodeDefaults = true }.encodeToString(this)
 }
+
+private const val KEY_CAPTURE_METHOD = "captureMethod"
+private const val KEY_CLIENT_TIMESTAMP = "clientTimeStamp"
+private const val CLIENT_PROVIDED = "ClientProvided"

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -127,7 +127,6 @@ internal class LayoutViewModel(
         pluginId = pluginModel.id
 
         if (layoutSchema != null && lastOfferIndex >= FIRST_OFFER_INDEX) {
-            handleSignalInitialise()
             sendViewState(currentOffer)
             setSuccessState(
                 LayoutUiState(
@@ -253,16 +252,6 @@ internal class LayoutViewModel(
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.slots[offerId].offer?.creative?.instanceGuid.orEmpty(),
                 pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
-            ),
-        )
-    }
-
-    private fun handleSignalInitialise() {
-        handlePlatformEvent(
-            RoktPlatformEvent(
-                eventType = EventType.SignalInitialize,
-                sessionId = experienceModel.sessionId,
-                parentGuid = pluginModel.instanceGuid,
             ),
         )
     }

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -277,50 +277,6 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `LayoutInitialised event should send the RoktPlatformEvent with SignalInitialize`() = runTest {
-        // Arrange
-        every { mapper.getSavedExperience() } returns mockk(relaxed = true) {
-            every { plugins } returns persistentListOf(
-                mockk(relaxed = true) {
-                    every { instanceGuid } returns "pluginInstanceGuid"
-                    every { id } returns "pluginId"
-                    every { settings } returns LayoutSettings(closeOnComplete = false)
-                    every { slots } returns persistentListOf(
-                        mockk(relaxed = true) {
-                            every { instanceGuid } returns "slotInstanceGuid"
-                            every { offer } returns mockk(relaxed = true) {
-                                every { creative } returns mockk(relaxed = true) {
-                                    every { instanceGuid } returns "creativeInstanceGuid"
-                                }
-                            }
-                        },
-                        mockk(relaxed = true) {
-                            every { instanceGuid } returns "slotInstanceGuid1"
-                            every { offer } returns mockk(relaxed = true) {
-                                every { creative } returns mockk(relaxed = true) {
-                                    every { instanceGuid } returns "creativeInstanceGuid1"
-                                }
-                            }
-                        },
-                    )
-                },
-            )
-        }
-
-        // Act
-        layoutViewModel.setEvent(LayoutContract.LayoutEvent.LayoutInitialised)
-
-        // Assert
-        verify(timeout = 2000) {
-            platformEvent.invoke(
-                match { event ->
-                    event[0].eventType == EventType.SignalInitialize && event[0].parentGuid == "pluginInstanceGuid"
-                },
-            )
-        }
-    }
-
-    @Test
     fun `FirstOfferLoaded should send the RoktPlatformEvent with SignalImpression for the layout and required metadata`() {
         // Act
         layoutViewModel.setEvent(LayoutContract.LayoutEvent.FirstOfferLoaded)
@@ -332,7 +288,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anyMatch {
                         it.eventType == EventType.SignalImpression &&
                             it.parentGuid == "pluginInstanceGuid" &&
-                            it.metadata.size == 3 &&
+                            it.metadata.size == 5 &&
                             it.metadata.any { data -> data.name == "pageRenderEngine" && data.value == "Layouts" } &&
                             it.metadata.any { data -> data.name == "pageSignalLoadStart" } &&
                             it.metadata.any { data -> data.name == "pageSignalLoadComplete" }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

* SignalInitialize is sent when the SDK receives the data and before start rendering.
* Add default metadata in the events object


Fixes [LAYOUT-1929](https://rokt.atlassian.net/browse/LAYOUT-1929)

### What Has Changed

Fix the SignalInitialize sent from the SDK

### How Has This Been Tested?

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
