### PR TITLE
LAYOUT-1929 - Fix duplicate SignalResponse events from CarouselDistributionComponent

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/CarouselDistributionComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CarouselDistributionComponent.kt
@@ -153,9 +153,12 @@ internal class CarouselDistributionComponent(
                             // Only progress to next offer if viewableItems is 1
                             if (viewableItems == DEFAULT_VIEWABLE_ITEMS) {
                                 onEventSent(event.copy(shouldProgress = true))
+                            } else {
+                                onEventSent(event)
                             }
+                        } else {
+                            onEventSent(event)
                         }
-                        onEventSent.invoke(event)
                     }
                 }
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Call the `onEventSent` once per event

Fixes [LAYOUT-1929](https://rokt.atlassian.net/browse/LAYOUT-1929)

### What Has Changed

Fix the condition in Carousel component 

### How Has This Been Tested?

Tested locally 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
