### PR TITLE
update the resources to use Rokt Prefix

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -44,6 +44,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 defaultConfig.targetSdk = 33
                 defaultConfig.versionName = sdkVersionName
                 defaultConfig.versionCode = sdkVersionCode
+                resourcePrefix = "rokt_" // Prefix for all resources
                 if (target.findProperty("useProductFlavours") as? String == "true") {
                     configureFlavors(this, buildConfigs)
                 }

--- a/roktux/src/main/res/values/rokt_attrs.xml
+++ b/roktux/src/main/res/values/rokt_attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <declare-styleable name="RoktLayoutView">
         <!-- Sets the location for the RoktLayout View -->
-        <attr name="location" format="string" />
+        <attr name="location" format="string" tools:ignore="ResourceName" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

This PR is to force a prefix `rokt` for all resources in the Android library.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-485))]

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
