### PR TITLE
LAYOUT-1967 - Send font diagnostics errors when requested value is not null

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
@@ -1083,7 +1083,7 @@ internal class ModifierFactory {
         } ?: text
         val fontFamily = try {
             val family = fontFamilyMap[stylingUiProperties.fontFamily ?: defaultFontFamily]
-            if (family == null) {
+            if (family == null && stylingUiProperties.fontFamily != null) {
                 throw IllegalStateException("Could not load font ${stylingUiProperties.fontFamily}")
             }
             resolver.resolve(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

When the requested fontFamily is not available, send the diagnostic error

Fixes LAYOUT-1967

### What Has Changed

Fix sending null as failed fontFamily in diagnostics

### How Has This Been Tested?

Tested with demo layouts

### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
