### PR TITLE
LAYOUT-1970 - Fix the empty overlay issue

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -135,6 +135,8 @@ fun RoktLayout(
                 },
             )
         }
+    } else {
+        onUxEvent(RoktUxEvent.LayoutCompleted(roktUxConfig.viewStateConfig?.viewState?.pluginId ?: ""))
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

When the layout is loaded from cache and the state is dismissed, trigger `LayoutCompleted` uxEvent to let the consumer know.

Fixes [LAYOUT-1970](https://rokt.atlassian.net/browse/LAYOUT-1970)

### What Has Changed

Trigger UxEvent when the layout cannot be loaded because the saved state is dismissed

### How Has This Been Tested?

Tested with stage environment

### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
