### PR TITLE
NI-493 Close Animation Not Playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Add to Cart nodes
 - View state caching
 
+### Fixed
+
+- Exit animation not firing prior to closure-related UX events
+
 ## [0.2.0] - 2024-12-17
 
 ### Added

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/base/BaseViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/base/BaseViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.rokt.roktux.viewmodel.base.BaseContract.BaseViewState
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,7 +63,7 @@ internal abstract class BaseViewModel<Event, UiState, Effect> : ViewModel() {
 
     protected fun setEffect(builder: () -> Effect) {
         val effectValue = builder()
-        viewModelScope.launch { _effect.send(effectValue) }
+        viewModelScope.launch(Dispatchers.Main.immediate) { _effect.send(effectValue) }
     }
 
     open fun handleError(exception: Throwable) {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -206,12 +206,12 @@ internal class LayoutViewModel(
             }
 
             is LayoutContract.LayoutEvent.CloseSelected -> {
-                uxEvent(RoktUxEvent.LayoutClosed(pluginId))
                 sendDismissEvent(if (event.isDismissed) DISMISSED else CLOSE_BUTTON)
                 setEffect {
                     LayoutContract.LayoutEffect.CloseLayout
                 }
                 sendViewState(isDismissed = true)
+                uxEvent(RoktUxEvent.LayoutClosed(pluginId))
             }
 
             is LayoutContract.LayoutEvent.UrlSelected -> {
@@ -355,12 +355,12 @@ internal class LayoutViewModel(
                 )
             } else {
                 if (pluginModel.settings.closeOnComplete) {
-                    uxEvent(RoktUxEvent.LayoutCompleted(pluginId))
                     sendViewState(isDismissed = true)
                     sendDismissEvent(NO_MORE_OFFERS_TO_SHOW)
                     setEffect {
                         LayoutContract.LayoutEffect.CloseLayout
                     }
+                    uxEvent(RoktUxEvent.LayoutCompleted(pluginId))
                 }
                 currentUiState
             }
@@ -381,12 +381,12 @@ internal class LayoutViewModel(
                 )
             } else {
                 if (pluginModel.settings.closeOnComplete) {
-                    uxEvent(RoktUxEvent.LayoutCompleted(pluginId))
                     sendViewState(isDismissed = true)
                     sendDismissEvent(NO_MORE_OFFERS_TO_SHOW)
                     setEffect {
                         LayoutContract.LayoutEffect.CloseLayout
                     }
+                    uxEvent(RoktUxEvent.LayoutCompleted(pluginId))
                 }
                 currentUiState
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The close related uxevents can be received and utilised to close an activity before the layout close animation is triggered. This changes updates the effects on the UI to occur immediately so that the animation is triggered before the uxevent.

Fixes [NI-493](https://rokt.atlassian.net/browse/NI-493)

### What Has Changed

Run effects using Main.immediate
Send UXEvent after setting event

### How Has This Been Tested?

Tested with physical device

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
