### PR TITLE
LAYOUT-2037 - Fix bottomsheet border radius issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BottomSheet border radius value is not applied correctly
+
 ## [0.3.0] - 2025-02-05
 
 ### Added

--- a/roktux/src/main/java/com/rokt/roktux/component/BottomSheetComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/BottomSheetComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.roktux.utils.interceptTap
@@ -55,6 +56,10 @@ internal class BottomSheetComponent(
                 },
             )
 
+        val bottomSheetShape =
+            model.child.ownModifiers?.getOrNull(breakpointIndex)?.default?.let {
+                modifierFactory.createBackgroundShape(it)
+            } ?: RectangleShape
         var hasUserInteracted by remember { mutableStateOf(false) }
         ModalBottomSheet(
             onDismissRequest = {
@@ -63,6 +68,7 @@ internal class BottomSheetComponent(
                 }
                 onEventSent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = true))
             },
+            shape = bottomSheetShape,
             sheetState = modalBottomSheetState,
             scrimColor = scrimColor ?: BottomSheetDefaults.ScrimColor,
             dragHandle = {},

--- a/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
@@ -363,17 +363,7 @@ internal class ModifierFactory {
         context: Context,
         imageLoader: ImageLoader,
     ): Modifier {
-        val shape = properties.border?.let {
-            if (it.borderRadius > 0.dp) {
-                if (it.useTopCornerRadius) {
-                    RoundedCornerShape(topStart = it.borderRadius, topEnd = it.borderRadius)
-                } else {
-                    RoundedCornerShape(it.borderRadius)
-                }
-            } else {
-                RectangleShape
-            }
-        } ?: RectangleShape
+        val shape = createBackgroundShape(properties = properties)
         return this
             .then(properties.margin?.let { Modifier.padding(it) } ?: Modifier)
             .then(properties.offset?.let { Modifier.offset(it.x, it.y) } ?: Modifier)
@@ -1026,6 +1016,18 @@ internal class ModifierFactory {
             }
         }
     }
+
+    fun createBackgroundShape(properties: BaseModifierProperties): Shape = properties.border?.let {
+        if (it.borderRadius > 0.dp) {
+            if (it.useTopCornerRadius) {
+                RoundedCornerShape(topStart = it.borderRadius, topEnd = it.borderRadius)
+            } else {
+                RoundedCornerShape(it.borderRadius)
+            }
+        } else {
+            RectangleShape
+        }
+    } ?: RectangleShape
 
     private fun createTextProperties(
         isPressed: Boolean,

--- a/roktux/src/test/assets/BottomSheetComponent/BottomSheet_with_height.json
+++ b/roktux/src/test/assets/BottomSheetComponent/BottomSheet_with_height.json
@@ -1,0 +1,85 @@
+{
+  "type": "BottomSheet",
+  "node": {
+    "allowBackdropToClose": true,
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "background": {
+                "backgroundColor": {
+                  "light": "#ffffff",
+                  "dark": "#ffffff"
+                }
+              },
+              "border": {
+                "borderRadius": 4.0,
+                "borderWidth": "4",
+                "borderColor": {
+                  "light": "#ffff00"
+                }
+              },
+              "dimension": {
+                "height": {
+                  "type": "fixed",
+                  "value": 20
+                }
+              },
+              "spacing": {
+                "padding": "16 0 0 0",
+                "margin": "0 0 0 0"
+              }
+            }
+          }
+        ],
+        "wrapper": [
+          {
+            "default": {
+              "background": {
+                "backgroundColor": {
+                  "light": "#520E0A13",
+                  "dark": "#520E0A13"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "children": [
+      {
+        "type": "RichText",
+        "node": {
+          "styles": {
+            "elements": {
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "width": {
+                        "type": "fit",
+                        "value": "fit-width"
+                      }
+                    },
+                    "text": {
+                      "textColor": {
+                        "light": "#171717",
+                        "dark": "#171717"
+                      },
+                      "fontSize": 16.0,
+                      "fontWeight": "500",
+                      "lineHeight": 22.0,
+                      "horizontalTextAlign": "center"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "value": "Purchase successful"
+        }
+      }
+    ]
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/BottomSheetComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/BottomSheetComponentTest.kt
@@ -1,0 +1,25 @@
+package com.rokt.roktux.component
+
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
+import com.rokt.core.testutils.annotations.DcuiNodeJson
+import com.rokt.roktux.testutil.BaseDcuiEspressoTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BottomSheetComponentTest : BaseDcuiEspressoTest() {
+
+    @Test
+    @DcuiNodeJson(jsonFile = "BottomSheetComponent/BottomSheet_with_height.json")
+    fun testBottomSheetComponentWithHeight() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Purchase successful").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertHeightIsEqualTo(20.dp)
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The new material bottomsheet component is using the shape parameter to draw the container. The default shape is with a rounded corner one.
Create the shape and apply it when composing the `ModalBottomSheet` component.

Fixes [LAYOUT-2037](https://rokt.atlassian.net/browse/LAYOUT-2037)

### What Has Changed

Fix the bottomsheet border radius issue by applying the correct shape background

### How Has This Been Tested?

Tested locally with mock responses

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
