### PR TITLE
LAYOUT-2076 - Fix the pressed state style issue - breakdown complex object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - BottomSheet border radius value is not applied correctly
+- Button pressed state not being applied
 
 ## [0.3.0] - 2025-02-05
 

--- a/modelmapper/src/main/java/com/rokt/modelmapper/mappers/DisplayModelMapper.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/mappers/DisplayModelMapper.kt
@@ -70,16 +70,8 @@ internal fun transformBottomSheet(
         },
     )?.map {
         it.copy(
-            default = it.default.copy(
-                border = it.default.border?.copy(
-                    useTopCornerRadius = true,
-                ),
-            ),
-            pressed = it.pressed?.copy(
-                border = it.pressed.border?.copy(
-                    useTopCornerRadius = true,
-                ),
-            ),
+            default = it.default.copy(borderUseTopCornerRadius = true),
+            pressed = it.pressed?.copy(borderUseTopCornerRadius = true),
         )
     }?.toImmutableList()
     val wrapperStyles = bottomSheetModel.node.styles?.elements?.wrapper?.toImmutableList()

--- a/modelmapper/src/main/java/com/rokt/modelmapper/mappers/ModifierMapper.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/mappers/ModifierMapper.kt
@@ -10,12 +10,10 @@ import com.rokt.modelmapper.uimodel.AlignmentUiModel
 import com.rokt.modelmapper.uimodel.ArrangementUiModel
 import com.rokt.modelmapper.uimodel.BackgroundImageUiModel
 import com.rokt.modelmapper.uimodel.BorderStyleUiModel
-import com.rokt.modelmapper.uimodel.BorderUiModel
 import com.rokt.modelmapper.uimodel.ContainerProperties
 import com.rokt.modelmapper.uimodel.HeightUiModel
 import com.rokt.modelmapper.uimodel.ModifierProperties
 import com.rokt.modelmapper.uimodel.OpenLinks
-import com.rokt.modelmapper.uimodel.ShadowUiModel
 import com.rokt.modelmapper.uimodel.StateBlock
 import com.rokt.modelmapper.uimodel.ThemeColorUiModel
 import com.rokt.modelmapper.uimodel.WidthUiModel
@@ -117,22 +115,21 @@ internal fun transformModifier(
     margin = spacingProperties?.margin?.let { transformPadding(it) },
     offset = spacingProperties?.offset?.let { transformOffset(it) },
     rotateZ = dimensionProperties?.rotateZ,
-    shadow = containerProperties?.shadow?.let {
-        ShadowUiModel(
-            ThemeColorUiModel(it.color.light, it.color.dark),
-            it.blurRadius?.dp ?: 0.dp,
-            it.spreadRadius ?: 0F,
-            DpOffset(it.offsetX?.dp ?: 0.dp, it.offsetY?.dp ?: 0.dp),
-        )
+    shadowColor = containerProperties?.shadow?.color?.let { ThemeColorUiModel(it.light, it.dark) },
+    shadowOffset = containerProperties?.shadow?.let { DpOffset(it.offsetX?.dp ?: 0.dp, it.offsetY?.dp ?: 0.dp) },
+    shadowBlurRadius = containerProperties?.shadow?.blurRadius?.dp,
+    shadowSpreadRadius = containerProperties?.shadow?.spreadRadius,
+    borderColor = borderProperties?.borderColor?.let { ThemeColorUiModel(it.light, it.dark) },
+    borderRadius = borderProperties?.borderRadius?.dp,
+    borderWidth = borderProperties?.borderWidth?.let { transformBorderWidth(it) },
+    borderStyle = if (borderProperties?.borderStyle ==
+        BorderStyle.Dashed
+    ) {
+        BorderStyleUiModel.Dashed
+    } else {
+        BorderStyleUiModel.Solid
     },
-    border = borderProperties?.let {
-        BorderUiModel(
-            ThemeColorUiModel(it.borderColor?.light, it.borderColor?.dark),
-            it.borderRadius?.dp ?: 0.dp,
-            transformBorderWidth(it.borderWidth ?: "0"),
-            if (it.borderStyle == BorderStyle.Dashed) BorderStyleUiModel.Dashed else BorderStyleUiModel.Solid,
-        )
-    },
+    borderUseTopCornerRadius = false,
     blurRadius = containerProperties?.blur,
     backgroundColor = backgroundProperties?.backgroundColor?.let { ThemeColorUiModel(it.light, it.dark) },
     backgroundImage = transformBackgroundImage(backgroundProperties?.backgroundImage),

--- a/modelmapper/src/main/java/com/rokt/modelmapper/uimodel/LayoutSchemaUiModel.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/uimodel/LayoutSchemaUiModel.kt
@@ -337,8 +337,15 @@ interface BaseModifierProperties {
     val maxWidth: Dp?
     val width: WidthUiModel?
     val height: HeightUiModel?
-    val shadow: ShadowUiModel?
-    val border: BorderUiModel?
+    val shadowColor: ThemeColorUiModel?
+    val shadowBlurRadius: Dp?
+    val shadowSpreadRadius: Float?
+    val shadowOffset: DpOffset?
+    val borderColor: ThemeColorUiModel?
+    val borderRadius: Dp?
+    val borderWidth: ImmutableList<Float>?
+    val borderStyle: BorderStyleUiModel?
+    val borderUseTopCornerRadius: Boolean?
     val blurRadius: Float?
     val backgroundColor: ThemeColorUiModel?
     val backgroundColorState: Color?
@@ -357,8 +364,15 @@ data class ModifierProperties(
     override val maxWidth: Dp? = null,
     override val width: WidthUiModel? = null,
     override val height: HeightUiModel? = null,
-    override val shadow: ShadowUiModel? = null,
-    override val border: BorderUiModel? = null,
+    override val shadowColor: ThemeColorUiModel? = null,
+    override val shadowBlurRadius: Dp? = null,
+    override val shadowSpreadRadius: Float? = null,
+    override val shadowOffset: DpOffset? = null,
+    override val borderColor: ThemeColorUiModel? = null,
+    override val borderRadius: Dp? = null,
+    override val borderWidth: ImmutableList<Float>? = null,
+    override val borderStyle: BorderStyleUiModel? = null,
+    override val borderUseTopCornerRadius: Boolean? = null,
     override val blurRadius: Float? = null,
     override val backgroundColor: ThemeColorUiModel? = null,
     override val backgroundColorState: Color? = null,
@@ -387,8 +401,15 @@ class TransitionModifierProperties(
     maxWidth: State<Dp?>,
     width: State<WidthUiModel?>,
     height: State<HeightUiModel?>,
-    override val shadow: ShadowUiModel?,
-    override val border: BorderUiModel?,
+    override val shadowColor: ThemeColorUiModel?,
+    override val shadowBlurRadius: Dp?,
+    override val shadowSpreadRadius: Float?,
+    override val shadowOffset: DpOffset?,
+    override val borderColor: ThemeColorUiModel?,
+    override val borderRadius: Dp?,
+    override val borderWidth: ImmutableList<Float>?,
+    override val borderStyle: BorderStyleUiModel?,
+    override val borderUseTopCornerRadius: Boolean?,
     override val backgroundColor: ThemeColorUiModel? = null,
     override var backgroundImage: BackgroundImageUiModel? = null,
     blurRadius: State<Float?>,
@@ -420,23 +441,6 @@ data class ContainerUiProperties(
     val horizontalArrangement: Arrangement.Horizontal,
     val verticalArrangement: Arrangement.Vertical,
     val gap: Dp? = null,
-)
-
-@Immutable
-data class ShadowUiModel(
-    val color: ThemeColorUiModel? = null,
-    val blurRadius: Dp,
-    val spreadRadius: Float,
-    val offset: DpOffset,
-)
-
-@Immutable
-data class BorderUiModel(
-    val borderColor: ThemeColorUiModel? = null,
-    val borderRadius: Dp,
-    val borderWidth: ImmutableList<Float>,
-    val borderStyle: BorderStyleUiModel,
-    val useTopCornerRadius: Boolean = false,
 )
 
 @Immutable

--- a/roktux/src/test/assets/RowComponent/Row_with_PressedStateBorder.json
+++ b/roktux/src/test/assets/RowComponent/Row_with_PressedStateBorder.json
@@ -1,0 +1,39 @@
+{
+  "type": "Row",
+  "node": {
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "border": {
+                "borderColor": {
+                  "light": "#ff0000"
+                },
+                "borderStyle": "solid",
+                "borderWidth": "1",
+                "borderRadius": 40
+              }
+            },
+            "pressed": {
+              "border": {
+                "borderColor": {
+                  "dark": null,
+                  "light": "#ff2222"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "children": [
+      {
+        "type": "BasicText",
+        "node": {
+          "value": "Test1"
+        }
+      }
+    ]
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/RowComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/RowComponentTest.kt
@@ -17,6 +17,7 @@ import com.rokt.core.testutils.annotations.DcuiOfferJson
 import com.rokt.core.testutils.annotations.TestPseudoState
 import com.rokt.core.testutils.annotations.WindowSize
 import com.rokt.core.testutils.assertion.assertBackgroundColor
+import com.rokt.core.testutils.assertion.assertBorderProperties
 import com.rokt.core.testutils.assertion.assertHeightFit
 import com.rokt.core.testutils.assertion.assertHeightWrapContent
 import com.rokt.core.testutils.assertion.assertOffsetValues
@@ -435,5 +436,21 @@ class RowComponentTest : BaseDcuiEspressoTest() {
     fun testRowBackgroundColorWithStatePressed() {
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
             .assertBackgroundColor("#00ff00")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "RowComponent/Row_with_PressedStateBorder.json")
+    @DcuiConfig(pseudoState = TestPseudoState(isPressed = true))
+    fun testRowBorderWithStatePressed() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertBorderProperties(borderWidth = 1f, borderColor = "#ff2222", borderRadius = 40f)
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "RowComponent/Row_with_PressedStateBorder.json")
+    @DcuiConfig(pseudoState = TestPseudoState(isPressed = false))
+    fun testRowBorderWithStateDefault() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertBorderProperties(borderWidth = 1f, borderColor = "#ff0000", borderRadius = 40f)
     }
 }

--- a/testutils/src/main/java/com/rokt/core/testutils/assertion/BorderAssertions.kt
+++ b/testutils/src/main/java/com/rokt/core/testutils/assertion/BorderAssertions.kt
@@ -1,0 +1,23 @@
+package com.rokt.core.testutils.assertion
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.unit.dp
+
+fun SemanticsNodeInteraction.assertBorderProperties(borderWidth: Float, borderColor: String, borderRadius: Float) =
+    assert(hasBorderProperties(borderWidth, borderColor, borderRadius))
+
+private fun hasBorderProperties(borderWidth: Float, borderColor: String, borderRadius: Float) =
+    SemanticsMatcher("Border properties not present") { node ->
+        val expectedBorderModifier = Modifier.border(
+            width = borderWidth.dp,
+            color = Color(android.graphics.Color.parseColor(borderColor)),
+            shape = RoundedCornerShape(borderRadius.dp),
+        )
+        node.layoutInfo.getModifierInfo().map { it.modifier }.contains(expectedBorderModifier)
+    }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Fix the issue with pressed state styles not being applied.

Fixes [LAYOUT-2076](https://rokt.atlassian.net/browse/LAYOUT-2076)

### What Has Changed

Apply the pressed style and default style of the current breakpoint if required.

### How Has This Been Tested?

Tested with mock json

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
