### PR TITLE
LAYOUT-2088 - Fix text color in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BottomSheet border radius value is not applied correctly
 - Button pressed state not being applied
+- Fix text color in dark mode for `BasicText` `Icons` and `ProgressIndicator` nodes
 
 ## [0.3.0] - 2025-02-05
 

--- a/roktux/src/main/java/com/rokt/roktux/component/BasicTextComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/BasicTextComponent.kt
@@ -28,7 +28,7 @@ internal class BasicTextComponent(private val modifierFactory: ModifierFactory) 
             textStyles = model.textStyles,
             breakpointIndex = breakpointIndex,
             isPressed = isPressed,
-            isDarkModeEnabled = false,
+            isDarkModeEnabled = isDarkModeEnabled,
             conditionalTransitionTextStyling = model.conditionalTransitionTextStyling,
             offerState = offerState,
             onEventSent = onEventSent,

--- a/roktux/src/main/java/com/rokt/roktux/component/IconComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/IconComponent.kt
@@ -27,7 +27,7 @@ internal class IconComponent(private val modifierFactory: ModifierFactory) :
                 textStyles = model.textStyles,
                 breakpointIndex = breakpointIndex,
                 isPressed = isPressed,
-                isDarkModeEnabled = false,
+                isDarkModeEnabled = isDarkModeEnabled,
                 defaultFontFamily = ROKT_ICONS_FONT_FAMILY,
                 offerState = offerState,
                 onEventSent = onEventSent,

--- a/roktux/src/main/java/com/rokt/roktux/component/ProgressIndicatorComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ProgressIndicatorComponent.kt
@@ -161,7 +161,7 @@ internal class ProgressIndicatorComponent(
                     textStyles = model.textStyles,
                     breakpointIndex = breakpointIndex,
                     isPressed = isPressed,
-                    isDarkModeEnabled = false,
+                    isDarkModeEnabled = isDarkModeEnabled,
                     baseStyles = baseModel.textStyles,
                     offerState = offerState,
                     onEventSent = onEventSent,

--- a/roktux/src/test/assets/IconComponent/StaticIcon_with_TextColor.json
+++ b/roktux/src/test/assets/IconComponent/StaticIcon_with_TextColor.json
@@ -1,0 +1,22 @@
+{
+  "type": "StaticIcon",
+  "node": {
+    "name": "Car",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "text": {
+                "textColor": {
+                  "light": "#FF0000",
+                  "dark": "#0000FF"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/assets/ProgressIndicatorComponent/ProgressIndicator.json
+++ b/roktux/src/test/assets/ProgressIndicatorComponent/ProgressIndicator.json
@@ -51,7 +51,8 @@
               },
               "text": {
                 "textColor": {
-                  "light": "#000000"
+                  "light": "#aa0000",
+                  "dark": "#ffff00"
                 },
                 "horizontalTextAlign": "center",
                 "fontSize": 10,
@@ -88,7 +89,8 @@
               },
               "text": {
                 "textColor": {
-                  "light": "#000000"
+                  "light": "#000000",
+                  "dark": "#ff0000"
                 },
                 "horizontalTextAlign": "center",
                 "fontSize": 10,

--- a/roktux/src/test/assets/TextComponent/BasicText_with_TextColor.json
+++ b/roktux/src/test/assets/TextComponent/BasicText_with_TextColor.json
@@ -1,0 +1,22 @@
+{
+  "type": "BasicText",
+  "node": {
+    "value": "Test",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "text": {
+                "textColor": {
+                  "light": "#ff0000",
+                  "dark": "#0000ff"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/IconComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/IconComponentTest.kt
@@ -9,6 +9,7 @@ import com.rokt.core.testutils.annotations.DcuiConfig
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.core.testutils.annotations.DcuiOfferJson
 import com.rokt.core.testutils.assertion.assertBackgroundColor
+import com.rokt.core.testutils.assertion.assertTextColor
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -100,5 +101,25 @@ class IconComponentTest : BaseDcuiEspressoTest() {
             .assertIsDisplayed()
             .assertTextEquals("PercentIcon")
             .assertBackgroundColor("#bb1010")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "IconComponent/StaticIcon_with_TextColor.json")
+    @DcuiConfig(isDarkModeEnabled = true)
+    fun testStaticIconRendersWithDarkTextColor() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+            .assertTextEquals("Car")
+            .assertTextColor("#0000FF")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "IconComponent/StaticIcon_with_TextColor.json")
+    @DcuiConfig(isDarkModeEnabled = false)
+    fun testStaticIconRendersWithLightTextColor() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+            .assertTextEquals("Car")
+            .assertTextColor("#FF0000")
     }
 }

--- a/roktux/src/test/java/com/rokt/roktux/component/ProgressIndicatorComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/ProgressIndicatorComponentTest.kt
@@ -18,6 +18,7 @@ import com.rokt.core.testutils.annotations.DcuiNodeComponentState
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.core.testutils.annotations.WindowSize
 import com.rokt.core.testutils.assertion.assertHeightWrapContent
+import com.rokt.core.testutils.assertion.assertTextColor
 import com.rokt.core.testutils.assertion.assertWidthWrapContent
 import com.rokt.core.testutils.assertion.hasBackgroundColor
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
@@ -384,5 +385,25 @@ class ProgressIndicatorComponentTest : BaseDcuiEspressoTest() {
         composeTestRule.onNodeWithText("1", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule.onNodeWithText("2", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule.onNodeWithText("3", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "ProgressIndicatorComponent/ProgressIndicator.json")
+    @DcuiConfig(isDarkModeEnabled = true)
+    @DcuiNodeComponentState(currentOffer = 1, totalOffer = 3)
+    fun testProgressIndicatorRendersWithDarkModeTextColor() {
+        composeTestRule.onNodeWithText("1", useUnmergedTree = true).assertTextColor("#ff0000")
+        composeTestRule.onNodeWithText("2", useUnmergedTree = true).assertTextColor("#ffff00")
+        composeTestRule.onNodeWithText("3", useUnmergedTree = true).assertTextColor("#ff0000")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "ProgressIndicatorComponent/ProgressIndicator.json")
+    @DcuiConfig(isDarkModeEnabled = false)
+    @DcuiNodeComponentState(currentOffer = 1, totalOffer = 3)
+    fun testProgressIndicatorRendersWithLightModeTextColor() {
+        composeTestRule.onNodeWithText("1", useUnmergedTree = true).assertTextColor("#000000")
+        composeTestRule.onNodeWithText("2", useUnmergedTree = true).assertTextColor("#aa0000")
+        composeTestRule.onNodeWithText("3", useUnmergedTree = true).assertTextColor("#000000")
     }
 }

--- a/roktux/src/test/java/com/rokt/roktux/component/TextComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/TextComponentTest.kt
@@ -197,6 +197,24 @@ class TextComponentTest : BaseDcuiEspressoTest() {
     }
 
     @Test
+    @DcuiNodeJson(jsonFile = "TextComponent/BasicText_with_TextColor.json")
+    @DcuiConfig(isDarkModeEnabled = true)
+    fun testBasicTextComponentWithDarkModeTextColor() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+            .assertTextColor("#0000ff")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "TextComponent/BasicText_with_TextColor.json")
+    @DcuiConfig(isDarkModeEnabled = false)
+    fun testBasicTextComponentWithLightModeTextColor() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+            .assertTextColor("#ff0000")
+    }
+
+    @Test
     @DcuiNodeJson(
         jsonString = """
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The DarkMode state was not used for constructing the styles of `BasicTextComponent`, `IconComponent` and `ProgressIndicatorComponent`.

Fixes [LAYOUT-2088](https://rokt.atlassian.net/browse/LAYOUT-2088)

### What Has Changed

Use the correct parameter to construct the styles so that the dark mode color is used.
Added tests to validate that the correct color is applied in light and dark modes.

### How Has This Been Tested?

Added unit tests and mock json.
Tested using mock json

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
