### PR TITLE
NI-641 Fix Overlay BackDrop Close

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
@@ -1,6 +1,7 @@
 package com.rokt.roktux.component
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,8 +11,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.window.Popup
@@ -51,34 +54,26 @@ internal class OverlayComponent(
             }
         }
 
+        // This box is draw edge to edge on the screen as Popup does not draw edge to edge
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .then(insetsPadding)
                 .then(
-                    modifierFactory
-                        .createModifier(
-                            modifierPropertiesList = model.ownModifiers,
-                            conditionalTransitionModifier = model.conditionalTransitionModifiers,
-                            breakpointIndex = breakpointIndex,
-                            isPressed = isPressed,
-                            isDarkModeEnabled = isDarkModeEnabled,
-                            offerState = offerState,
-                        ),
+                    Modifier.background(
+                        modifierFactory
+                            .createBackground(
+                                modifierProperties = model.ownModifiers,
+                                index = breakpointIndex,
+                                isPressed = isPressed,
+                                isDarkModeEnabled = isDarkModeEnabled,
+                            ) ?: Color.Transparent,
+                    ),
                 )
-                .pointerInput(Unit) {
-                    detectTapGestures {
-                        if (model.allowBackdropToClose) {
-                            isClosedByBackdrop = true
-                            onEventSent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = true))
-                        }
-                    }
-                }
-                .animateContentSize()
                 .then(modifier),
         ) {
             Popup(
-                alignment = BiasAlignment(container.arrangementBias, container.alignmentBias),
+                alignment = Alignment.TopStart,
                 properties = PopupProperties(
                     dismissOnBackPress = true,
                     // This is handled by the clickable modifier on the Box
@@ -93,21 +88,49 @@ internal class OverlayComponent(
                     }
                 },
             ) {
-                factory.CreateComposable(
-                    model = model.child,
-                    modifier = Modifier.pointerInput(Unit) {
-                        // This is to avoid sending the click events to parent which may close the overlay
-                        interceptTap(
-                            pass = PointerEventPass.Main,
-                            shouldConsume = true,
-                        ) {}
-                    },
-                    isPressed = isPressed,
-                    offerState = offerState,
-                    isDarkModeEnabled = isDarkModeEnabled,
-                    breakpointIndex = breakpointIndex,
-                    onEventSent = onEventSent,
-                )
+                // This box is to intercept the click events outside the popup as popup handles the click events outside the popup
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(
+                            modifierFactory
+                                .createModifier(
+                                    modifierPropertiesList = model.ownModifiers,
+                                    conditionalTransitionModifier = model.conditionalTransitionModifiers,
+                                    breakpointIndex = breakpointIndex,
+                                    isPressed = isPressed,
+                                    isDarkModeEnabled = isDarkModeEnabled,
+                                    offerState = offerState,
+                                ),
+                        )
+                        .pointerInput(Unit) {
+                            detectTapGestures {
+                                if (model.allowBackdropToClose) {
+                                    isClosedByBackdrop = true
+                                    onEventSent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = true))
+                                }
+                            }
+                        }
+                        .animateContentSize()
+                        .then(modifier),
+                    contentAlignment = BiasAlignment(container.arrangementBias, container.alignmentBias),
+                ) {
+                    factory.CreateComposable(
+                        model = model.child,
+                        modifier = Modifier.pointerInput(Unit) {
+                            // This is to avoid sending the click events to parent which may close the overlay
+                            interceptTap(
+                                pass = PointerEventPass.Main,
+                                shouldConsume = true,
+                            ) {}
+                        },
+                        isPressed = isPressed,
+                        offerState = offerState,
+                        isDarkModeEnabled = isDarkModeEnabled,
+                        breakpointIndex = breakpointIndex,
+                        onEventSent = onEventSent,
+                    )
+                }
             }
         }
     }

--- a/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
@@ -92,17 +92,6 @@ internal class OverlayComponent(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .then(
-                            modifierFactory
-                                .createModifier(
-                                    modifierPropertiesList = model.ownModifiers,
-                                    conditionalTransitionModifier = model.conditionalTransitionModifiers,
-                                    breakpointIndex = breakpointIndex,
-                                    isPressed = isPressed,
-                                    isDarkModeEnabled = isDarkModeEnabled,
-                                    offerState = offerState,
-                                ),
-                        )
                         .pointerInput(Unit) {
                             detectTapGestures {
                                 if (model.allowBackdropToClose) {

--- a/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/OverlayComponent.kt
@@ -104,6 +104,16 @@ internal class OverlayComponent(
                         .then(modifier),
                     contentAlignment = BiasAlignment(container.arrangementBias, container.alignmentBias),
                 ) {
+                    var childModifier: Modifier = Modifier
+                    modifierFactory.createContainerUiProperties(
+                        containerProperties = model.child.containerProperties,
+                        index = breakpointIndex,
+                        isPressed = isPressed,
+                    ).also { container ->
+                        container.selfAlignmentBias?.let {
+                            childModifier = childModifier.then(Modifier.align(BiasAlignment(0F, it)))
+                        }
+                    }
                     factory.CreateComposable(
                         model = model.child,
                         modifier = Modifier.pointerInput(Unit) {
@@ -112,7 +122,7 @@ internal class OverlayComponent(
                                 pass = PointerEventPass.Main,
                                 shouldConsume = true,
                             ) {}
-                        },
+                        }.then(childModifier),
                         isPressed = isPressed,
                         offerState = offerState,
                         isDarkModeEnabled = isDarkModeEnabled,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

This PR is to fix the `allowBackdropToClose` for OverlayComponent which was triggered when we enable `edgeToedge` display.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-641))]


### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
