### PR TITLE
NOJIRA - Update Maven plugin to RC that supports snapshots

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    kotlin("jvm") version "2.1.10"
     `kotlin-dsl`
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,5 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 enableComposeCompilerMetrics=true
 enableComposeCompilerReports=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidxHiltNavigationCompose = "1.0.0"
 hilt = "2.51.1"
 activity = "1.9.2"
 constraintlayout = "2.1.4"
-mavenPublish = "0.30.0"
+mavenPublish = "0.31.0-rc1"
 kover = "0.9.1"
 
 roktUxHelper = "0.2.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Maven plugin has been updated with the RC that supports snapshots. This PR updates the version for testing pending full release.

[Ref](https://github.com/vanniktech/gradle-maven-publish-plugin/pull/894#issuecomment-2695419022)

### What Has Changed

- toml versions

### How Has This Been Tested?

N/A

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
