### PR TITLE
NOJIRA - Update maven publish to RC2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidxHiltNavigationCompose = "1.0.0"
 hilt = "2.51.1"
 activity = "1.9.2"
 constraintlayout = "2.1.4"
-mavenPublish = "0.31.0-rc1"
+mavenPublish = "0.31.0-rc2"
 kover = "0.9.1"
 
 roktUxHelper = "0.2.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Maven plugin has been updated with the RC that supports snapshots. This PR updates to RC2 which fixes the 401 issue for testing pending full release.

[Ref](https://github.com/vanniktech/gradle-maven-publish-plugin/pull/910)

### What Has Changed

- Maven publish version

### How Has This Been Tested?

N/A

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
- [X] New and existing unit tests pass locally with my changes.
