### PR TITLE
NI-678 Try Setting viewModelStore before NavHost composable

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/GroupedDistributionComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/GroupedDistributionComponent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -74,6 +75,17 @@ internal class GroupedDistributionComponent(
         )
         LaunchedEffect(key1 = viewableItems) {
             onEventSent(LayoutContract.LayoutEvent.ViewableItemsChanged(viewableItems))
+        }
+
+        val viewModelStoreOwner = LocalViewModelStoreOwner.current
+        try {
+            checkNotNull(viewModelStoreOwner) {
+                "NavHost requires a ViewModelStoreOwner to be provided via LocalViewModelStoreOwner"
+            }
+            navController.setViewModelStore(viewModelStoreOwner.viewModelStore)
+        } catch (e: Exception) {
+            onEventSent(LayoutContract.LayoutEvent.UiException(e, true))
+            return
         }
 
         NavHost(

--- a/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
@@ -1144,7 +1144,7 @@ internal class ModifierFactory {
             )
             fontFamilyMap[stylingUiProperties.fontFamily ?: defaultFontFamily] ?: FontFamily.Default
         } catch (e: Exception) {
-            onEventSent(LayoutContract.LayoutEvent.UiException(e))
+            onEventSent(LayoutContract.LayoutEvent.UiException(e, false))
             FontFamily.Default
         }
         return TextStyleUiState(

--- a/roktux/src/main/java/com/rokt/roktux/component/OneByOneDistributionComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/OneByOneDistributionComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -63,6 +64,17 @@ internal class OneByOneDistributionComponent(
             } else {
                 firstRender = false
             }
+        }
+
+        val viewModelStoreOwner = LocalViewModelStoreOwner.current
+        try {
+            checkNotNull(viewModelStoreOwner) {
+                "NavHost requires a ViewModelStoreOwner to be provided via LocalViewModelStoreOwner"
+            }
+            navController.setViewModelStore(viewModelStoreOwner.viewModelStore)
+        } catch (e: Exception) {
+            onEventSent(LayoutContract.LayoutEvent.UiException(e, true))
+            return
         }
 
         NavHost(

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
@@ -29,7 +29,7 @@ internal class LayoutContract {
         data class SetCurrentOffer(val currentOffer: Int) : LayoutEvent
         data class SignalViewed(val offerId: Int) : LayoutEvent
         data class OfferVisibilityChanged(val offerId: Int, val visible: Boolean) : LayoutEvent
-        data class UiException(val throwable: Throwable) : LayoutEvent
+        data class UiException(val throwable: Throwable, val closeLayout: Boolean) : LayoutEvent
     }
 
     sealed interface LayoutEffect : BaseContract.BaseEffect {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -271,7 +271,7 @@ internal class LayoutViewModel(
                     setEffect {
                         LayoutContract.LayoutEffect.CloseLayout(
                             onClose = {
-                                uxEvent(RoktUxEvent.LayoutClosed(pluginId))
+                                uxEvent(RoktUxEvent.LayoutFailure())
                             },
                         )
                     }

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -267,6 +267,15 @@ internal class LayoutViewModel(
             }
 
             is LayoutContract.LayoutEvent.UiException -> {
+                if (::experienceModel.isInitialized && event.closeLayout) {
+                    setEffect {
+                        LayoutContract.LayoutEffect.CloseLayout(
+                            onClose = {
+                                uxEvent(RoktUxEvent.LayoutClosed(pluginId))
+                            },
+                        )
+                    }
+                }
                 if (!(::experienceModel.isInitialized && experienceModel.options.useDiagnosticEvents)) {
                     return
                 }

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -298,4 +298,19 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
             )
         }
     }
+
+    @Test
+    fun `UiException Event should send SignalSdkDiagnostic PlatformEvent`() = runTest {
+        // Act
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.UiException(IllegalAccessException("no access"), true))
+
+        // Assert
+        verify(exactly = 0) {
+            platformEvent.invoke(
+                match { event ->
+                    event[0].eventType == EventType.SignalSdkDiagnostic
+                },
+            )
+        }
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background
This PR is to address the issue where the `viewModelStore` is not set before the `NavHost` composable is used. NavHost composable sets the viewModelStore, so we do a pre-checking here.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-678))]

### How Has This Been Tested?
- Unit test has been added

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
