### PR TITLE
LAYOUT-2194 - Add layoutId to OpenUrl event

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -56,9 +56,19 @@ sealed interface RoktUxEvent {
      */
     data class LayoutFailure(val layoutId: String? = null) : RoktUxEvent
 
+    /**
+     * OpenUrl event will be triggered when user clicks on a link or button with a Url action
+     * @param url - url to open
+     * @param id - internal identifier of the url
+     * @param layoutId - layout identifier
+     * @param type - type of the url. internal(internal web browser), external(external web browser), passthrough
+     * @param onClose - callback when url is closed
+     * @param onError - callback when url fails to open
+     */
     data class OpenUrl(
         val url: String,
         val id: String,
+        val layoutId: String,
         val type: OpenLinks,
         val onClose: (id: String) -> Unit,
         val onError: (id: String, throwable: Throwable) -> Unit,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -495,6 +495,7 @@ internal class LayoutViewModel(
             val openUrlEvent = RoktUxEvent.OpenUrl(
                 url = url,
                 id = id,
+                layoutId = pluginId,
                 type = openLinks,
                 onClose = { urlId -> onUrlClosed(urlId, shouldProgress) }, // Pass the id to handle closure
                 onError = { _, throwable ->
@@ -523,6 +524,7 @@ internal class LayoutViewModel(
                     val openUrlEvent = RoktUxEvent.OpenUrl(
                         url = url,
                         id = id,
+                        layoutId = pluginId,
                         type = openLinks,
                         onClose = { urlId -> onUrlClosed(urlId, shouldProgress) }, // Pass the id to handle closure
                         onError = { _, throwable ->

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -280,6 +280,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     fun `UrlSelected Event should send OpenUrl Passthrough UxEvent when handleUrlByApp set to false`() = runTest {
         // Arrange
         initialize(handleUrlByApp = false)
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.LayoutInitialised)
 
         // Act
         layoutViewModel.setEvent(LayoutContract.LayoutEvent.UrlSelected("url", OpenLinks.Passthrough))
@@ -290,7 +291,8 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                 match { event ->
                     event::class.java == RoktUxEvent.OpenUrl::class.java &&
                         (event as RoktUxEvent.OpenUrl).url == "url" &&
-                        event.type == OpenLinks.Passthrough
+                        event.type == OpenLinks.Passthrough &&
+                        event.layoutId == "pluginId"
                 },
             )
         }


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

### Background

Add `layoutId` to the `OpenUrl` event

Fixes [LAYOUT-2194](https://rokt.atlassian.net/browse/LAYOUT-2194)

### What Has Changed

*   Add layoutId to OpenUrl event to identify the layout that triggers the event.
*   Update unit tests

### How Has This Been Tested?

Unit tested

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
