### PR TITLE
LAYOUT-2268 - Fix the border radius issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix border radius clipping issue
+
 ## [0.4.0] - 2025-02-27
 
 ### Added

--- a/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
@@ -467,9 +467,9 @@ internal class ModifierFactory {
             )
             .then(
                 properties.backgroundColorState?.let {
-                    Modifier.background(color = it, shape = shape)
+                    Modifier.clip(shape).background(color = it, shape = shape)
                 } ?: properties.backgroundColor?.let {
-                    Modifier.background(color = getUiThemeColor(it, isDarkModeEnabled), shape = shape)
+                    Modifier.clip(shape).background(color = getUiThemeColor(it, isDarkModeEnabled), shape = shape)
                 } ?: Modifier,
             )
             .then(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

When children are drawn on top of rounded corner area it was drawing outside the background shape.

Fixes [LAYOUT-2268](https://rokt.atlassian.net/browse/LAYOUT-2268)

### What Has Changed

Clip to the shape so that the rounded corner shape is applied properly.

### How Has This Been Tested?

Tested with mock JSON
```json
"border": {
  "borderColor": null,
  "borderStyle": null,
  "borderWidth": null,
  "borderRadius": 40
}
```

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/34c151e6-50e6-4d85-9bc6-062a6ea36417" width="200" /> | <img src="https://github.com/user-attachments/assets/29bcfc67-b2aa-481f-8e44-857a7671882e" width="200" /> |

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
