### PR TITLE
LAYOUT-2269 - Implement user interaction as SignalViewed proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enhanced offer viewed signals
+
 ### Fixed
 
 - Fix border radius clipping issue

--- a/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
@@ -14,6 +14,7 @@ import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.roktux.di.layout.LocalLayoutComponent
 import com.rokt.roktux.di.variants.marketing.MarketingComponent
 import com.rokt.roktux.utils.componentVisibilityChange
+import com.rokt.roktux.utils.onUserInteractionDetected
 import com.rokt.roktux.viewmodel.base.BaseContract
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
@@ -73,7 +74,9 @@ internal class LayoutVariantMarketingComponent(private val factory: LayoutUiMode
                                 )
                             },
                             viewModel.currentOffer,
-                        ),
+                        ).onUserInteractionDetected {
+                            viewModel.setEvent(LayoutContract.LayoutEvent.UserInteracted)
+                        },
                         isPressed = isPressed,
                         offerState = offerState.copy(
                             creativeCopy = state.value.creativeCopy,

--- a/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
+++ b/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
@@ -239,6 +239,20 @@ internal suspend fun PointerInputScope.interceptTap(
     }
 }
 
+internal fun Modifier.onUserInteractionDetected(onInteraction: () -> Unit): Modifier =
+    this then Modifier.pointerInput(Unit) {
+        awaitEachGesture {
+            val down = awaitFirstDown(pass = PointerEventPass.Initial)
+            do {
+                val event = awaitPointerEvent(pass = PointerEventPass.Final)
+                val change = event.changes[0]
+                if (change.id == down.id && !change.pressed) {
+                    onInteraction()
+                }
+            } while (event.changes.any { it.id == down.id && it.pressed })
+        }
+    }
+
 internal fun Modifier.componentVisibilityChange(
     callback: (identifier: Int, visible: Boolean) -> Unit,
     identifier: Int,

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
@@ -11,7 +11,9 @@ import io.mockk.mockk
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -77,9 +79,83 @@ class MarketingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `Other LayoutEvents should be propagated as LayoutVariantEffect`() = runTest {
+    fun `UserInteracted should set the the SetSignalViewed effect only once`() = runTest {
         // Given
         val event = LayoutContract.LayoutEvent.UserInteracted
+
+        // When
+        viewModel.setEvent(event)
+        viewModel.setEvent(event)
+        val effects = mutableListOf<MarketingVariantContract.LayoutVariantEffect>()
+        val job = launch {
+            viewModel.effect.collect { effects.add(it) }
+        }
+        advanceUntilIdle()
+        job.cancel()
+
+        // Then
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isEqualTo(MarketingVariantContract.LayoutVariantEffect.SetSignalViewed(0))
+    }
+
+    @Test
+    fun `OfferVisibilityChanged should trigger SetSignalViewed effect if the visibility was not changed within 1 second`() = runTest(ioDispatcher) {
+        // Given
+        val event = LayoutContract.LayoutEvent.OfferVisibilityChanged(0, true)
+
+        // When
+        viewModel.setEvent(event)
+        advanceUntilIdle()
+        val effect = viewModel.effect.first()
+
+        // Then
+        assertThat(effect).isEqualTo(MarketingVariantContract.LayoutVariantEffect.SetSignalViewed(0))
+    }
+
+    @Test
+    fun `OfferVisibilityChanged should not trigger SetSignalViewed effect when the visibility changed within 1 second`() = runTest(ioDispatcher) {
+        // Given
+        val event = LayoutContract.LayoutEvent.OfferVisibilityChanged(0, true)
+
+        // When
+        viewModel.setEvent(event)
+        viewModel.setEvent(event.copy(visible = false))
+        val effects = mutableListOf<MarketingVariantContract.LayoutVariantEffect>()
+        val job = launch {
+            viewModel.effect.collect { effects.add(it) }
+        }
+        advanceUntilIdle()
+        job.cancel()
+
+        // Then
+        assertThat(effects).isEmpty()
+    }
+
+    @Test
+    fun `OfferVisibilityChanged should not trigger SetSignalViewed if it was already triggered by UserInteracted event`() = runTest(ioDispatcher) {
+        // Given
+        val offerVisibilityEvent = LayoutContract.LayoutEvent.OfferVisibilityChanged(0, true)
+        val userInteractedEvent = LayoutContract.LayoutEvent.UserInteracted
+
+        // When
+        viewModel.setEvent(offerVisibilityEvent)
+        viewModel.setEvent(userInteractedEvent)
+        val effects = mutableListOf<MarketingVariantContract.LayoutVariantEffect>()
+        val job = launch {
+            viewModel.effect.collect { effects.add(it) }
+        }
+        advanceUntilIdle()
+        job.cancel()
+
+        // Then
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isEqualTo(MarketingVariantContract.LayoutVariantEffect.SetSignalViewed(0))
+    }
+
+    @Test
+    fun `Other LayoutEvents should be propagated as LayoutVariantEffect`() = runTest {
+        // Given
+        val event = LayoutContract.LayoutEvent.FirstOfferLoaded
 
         // When
         viewModel.setEvent(event)


### PR DESCRIPTION
### Background

Implement user interaction as SignalViewed proxy

Fixes [LAYOUT-2266](https://rokt.atlassian.net/browse/LAYOUT-2266)

### What Has Changed

* Detect user interaction on format container(offers)
* Trigger SignalViewed signal when the interaction is detected.
* Added unit tests

### How Has This Been Tested?

Added unit tests 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
