### PR TITLE
LAYOUT-2305 - Fix the accessibility readout in creative image component when alt text is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix border radius clipping issue
+- Image component accessibility issue when alt value is empty
 
 ## [0.4.0] - 2025-02-27
 

--- a/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -33,7 +35,7 @@ internal class ImageComponent(private val modifierFactory: ModifierFactory) :
             val url = if (isDarkModeEnabled) model.darkUrl ?: model.lightUrl else model.lightUrl
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current).data(url).build(),
-                contentDescription = model.alt,
+                contentDescription = null,
                 imageLoader = LocalLayoutComponent.current[ImageLoader::class.java],
                 modifier = modifier.then(
                     modifierFactory.createModifier(
@@ -43,7 +45,12 @@ internal class ImageComponent(private val modifierFactory: ModifierFactory) :
                         isPressed = isPressed,
                         isDarkModeEnabled = isDarkModeEnabled,
                         offerState = offerState,
-                    ),
+                    )
+                        .clearAndSetSemantics {
+                            if (!model.alt.isNullOrBlank()) {
+                                contentDescription = model.alt.orEmpty()
+                            }
+                        },
                 ),
                 onError = { onImageError = true },
             )

--- a/roktux/src/test/assets/ImageComponent/Image_with_AltText_empty.json
+++ b/roktux/src/test/assets/ImageComponent/Image_with_AltText_empty.json
@@ -1,0 +1,9 @@
+{
+  "type": "StaticImage",
+  "node": {
+    "url": {
+      "light": "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
+    },
+    "alt": ""
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/ImageComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/ImageComponentTest.kt
@@ -1,5 +1,7 @@
 package com.rokt.roktux.component
 
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -85,6 +87,21 @@ class ImageComponentTest : BaseDcuiEspressoTest() {
     fun testImageComponentAltText() {
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
             .assertContentDescriptionEquals("alternative text")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "ImageComponent/Image_with_AltText_empty.json")
+    fun testImageComponentAltTextEmpty() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assert(
+                SemanticsMatcher(
+                    "contentDescription is empty",
+                ) {
+                    it.layoutInfo.getModifierInfo().any { modifierInfo ->
+                        modifierInfo.modifier.javaClass.name.contains("ClearAndSetSemantics")
+                    }
+                },
+            )
     }
 
     @Ignore("Until dark mode")


### PR DESCRIPTION
### Background

When the alt value is empty or null, remove the accessibility focus from the image component

Fixes [LAYOUT-2305](https://rokt.atlassian.net/browse/LAYOUT-2305)

### What Has Changed

Remove the accessibility content description and clear the semantics if the alt value is empty or null

### How Has This Been Tested?

Added unit tests
Tested locally
```
{
  "light": "https://***r/Pica_pica_01.jpg",
  "dark": "",
  "alt": "This is a bird",
  "title": ""
}
```
[Screen_recording_20250331_141954.webm](https://github.com/user-attachments/assets/d227c20d-8b9c-4dcb-86d6-5a01655017ee)

```
{
  "light": "https://www.egretta.org/gallery/birds/Cyanistes_caeruleus_04.jpg",
  "dark": "",
  "alt": "",
  "title": ""
}
```
[Screen_recording_20250331_142030.webm](https://github.com/user-attachments/assets/a6dd7ad7-f184-45f5-94b9-906617b62f56)

### Notes


### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
