### PR TITLE
LAYOUT-2305 - Fix the accessibility

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
@@ -5,10 +5,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -20,6 +21,7 @@ import com.rokt.roktux.viewmodel.layout.OfferUiState
 internal class ImageComponent(private val modifierFactory: ModifierFactory) :
     ComposableComponent<LayoutSchemaUiModel.ImageUiModel> {
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     override fun Render(
         model: LayoutSchemaUiModel.ImageUiModel,
@@ -35,20 +37,21 @@ internal class ImageComponent(private val modifierFactory: ModifierFactory) :
             val url = if (isDarkModeEnabled) model.darkUrl ?: model.lightUrl else model.lightUrl
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current).data(url).build(),
-                contentDescription = null,
+                contentDescription = model.alt,
                 imageLoader = LocalLayoutComponent.current[ImageLoader::class.java],
                 modifier = modifier.then(
-                    modifierFactory.createModifier(
-                        modifierPropertiesList = model.ownModifiers,
-                        conditionalTransitionModifier = model.conditionalTransitionModifiers,
-                        breakpointIndex = breakpointIndex,
-                        isPressed = isPressed,
-                        isDarkModeEnabled = isDarkModeEnabled,
-                        offerState = offerState,
-                    )
-                        .clearAndSetSemantics {
-                            if (!model.alt.isNullOrBlank()) {
-                                contentDescription = model.alt.orEmpty()
+                    modifierFactory
+                        .createModifier(
+                            modifierPropertiesList = model.ownModifiers,
+                            conditionalTransitionModifier = model.conditionalTransitionModifiers,
+                            breakpointIndex = breakpointIndex,
+                            isPressed = isPressed,
+                            isDarkModeEnabled = isDarkModeEnabled,
+                            offerState = offerState,
+                        )
+                        .semantics {
+                            if (model.alt.isNullOrBlank()) {
+                                invisibleToUser()
                             }
                         },
                 ),

--- a/roktux/src/test/java/com/rokt/roktux/component/ImageComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/ImageComponentTest.kt
@@ -98,7 +98,7 @@ class ImageComponentTest : BaseDcuiEspressoTest() {
                     "contentDescription is empty",
                 ) {
                     it.layoutInfo.getModifierInfo().any { modifierInfo ->
-                        modifierInfo.modifier.javaClass.name.contains("ClearAndSetSemantics")
+                        modifierInfo.modifier.javaClass.name.contains("AppendedSemantics")
                     }
                 },
             )


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

### Background

When the alt value is empty or null, make it invisible to accessibility user so that there is no accessibility warning

Fixes [LAYOUT-2305](https://rokt.atlassian.net/browse/LAYOUT-2305)

### What Has Changed

Avoid the `Unexposed Text` warning by the Accessibility Scanner.
When the `contentDescription` is not set, it is still considered as a warning if we don't  make it invisible to the accessibility user.

### How Has This Been Tested?

Tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
