### PR TITLE
NOJIRA Image Dark Mode Alternating Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix border radius clipping issue
 - Image component accessibility issue when alt value is empty
+- Image component not showing when device is changed from dark mode to light mode
 
 ## [0.4.0] - 2025-02-27
 

--- a/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ImageComponent.kt
@@ -32,9 +32,9 @@ internal class ImageComponent(private val modifierFactory: ModifierFactory) :
         breakpointIndex: Int,
         onEventSent: (LayoutContract.LayoutEvent) -> Unit,
     ) {
-        var onImageError by remember { mutableStateOf(false) }
+        var onImageError by remember(isDarkModeEnabled) { mutableStateOf(false) }
+        val url = if (isDarkModeEnabled) model.darkUrl ?: model.lightUrl else model.lightUrl
         if (!onImageError) {
-            val url = if (isDarkModeEnabled) model.darkUrl ?: model.lightUrl else model.lightUrl
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current).data(url).build(),
                 contentDescription = model.alt,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

If the device is in light mode the image shows. If the device changes to dark mode the image is hidden. If the device goes back to light mode to image does not come back. This is because the error state is not being reset when dark mode status changes. 

Fixes NOJIRA

### What Has Changed

- Remember the error state using isDarkModeEnabled as the key

### How Has This Been Tested?

Tested locally where
Light mode (image shows) -> dark mode (image hidden) -> light mode (image returned)

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
