### PR TITLE
LAYOUT-2319 - Fix text transformation and html link behaviour in RichTextComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Fixed
+
+- Fixed html links not opening when textTransformation is set to upper case
+
 ## [0.5.0] - 2025-04-02
 
 ### Added

--- a/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ModifierFactory.kt
@@ -1017,6 +1017,7 @@ internal class ModifierFactory {
         defaultFontFamily: String? = null,
         conditionalTransitionTextStyling: ConditionalTransitionTextStyling? = null,
         baseStyles: ImmutableList<StateBlock<TextStylingUiProperties>>? = null,
+        isRichText: Boolean = false,
         onEventSent: (LayoutContract.LayoutEvent) -> Unit,
     ): TextStyleUiState {
         val transitionStyleState = evaluateState(
@@ -1043,6 +1044,7 @@ internal class ModifierFactory {
                 fontFamilyMap,
                 defaultFontFamily,
                 resolver,
+                isRichText,
                 onEventSent,
             )
         } else {
@@ -1060,6 +1062,7 @@ internal class ModifierFactory {
                     fontFamilyMap,
                     defaultFontFamily,
                     resolver,
+                    isRichText,
                     onEventSent,
                 )
             }
@@ -1111,9 +1114,10 @@ internal class ModifierFactory {
         fontFamilyMap: ImmutableMap<String, FontFamily>,
         defaultFontFamily: String?,
         resolver: FontFamily.Resolver,
+        isRichText: Boolean,
         onEventSent: (LayoutContract.LayoutEvent) -> Unit,
     ): TextStyleUiState {
-        val transformedText = stylingUiProperties.textTransform?.run {
+        val transformedText = stylingUiProperties.textTransform?.takeIf { !isRichText }?.run {
             when (this) {
                 TextUiTransform.Capitalize -> text.split(" ").joinToString(" ") { value ->
                     value.replaceFirstChar {

--- a/roktux/src/main/java/com/rokt/roktux/component/RichTextComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/RichTextComponent.kt
@@ -56,6 +56,7 @@ internal class RichTextComponent(private val modifierFactory: ModifierFactory) :
             isDarkModeEnabled = isDarkModeEnabled,
             conditionalTransitionTextStyling = model.conditionalTransitionTextStyling,
             offerState = offerState,
+            isRichText = true,
             onEventSent = onEventSent,
         )
         val linkStyleUiState = modifierFactory.createTextStyle(
@@ -66,6 +67,7 @@ internal class RichTextComponent(private val modifierFactory: ModifierFactory) :
             isDarkModeEnabled = isDarkModeEnabled,
             baseStyles = model.textStyles,
             offerState = offerState,
+            isRichText = true,
             onEventSent = onEventSent,
         )
 
@@ -82,7 +84,8 @@ internal class RichTextComponent(private val modifierFactory: ModifierFactory) :
                     letterSpacing = linkStyleUiState.textStyle.letterSpacing,
                     textDecoration = linkStyleUiState.textStyle.textDecoration,
                 ),
-                linkStyleUiState.textTransform,
+                textTransform = textStyleUiState.textTransform,
+                linkTextTransform = linkStyleUiState.textTransform,
             ) { url ->
                 onEventSent(LayoutContract.LayoutEvent.UrlSelected(url, model.openLinks))
             }
@@ -111,15 +114,16 @@ private fun String.asHTML(
     fontSize: TextUnit,
     urlSpanStyle: SpanStyle,
     textTransform: TextUiTransform,
+    linkTextTransform: TextUiTransform,
     onClick: (url: String) -> Unit,
 ) = buildAnnotatedString {
     val spanned = HtmlCompat.fromHtml(this@asHTML, HtmlCompat.FROM_HTML_MODE_COMPACT)
     val spans = spanned.getSpans<Any>(0, spanned.length)
-    var spannedString = spanned.toString()
+    var spannedString = getTransformText(spanned.toString(), textTransform)
     spans.filter { it !is BulletSpan }.forEach { span ->
         val start = spanned.getSpanStart(span)
         val end = spanned.getSpanEnd(span)
-        val spanString = getTransformText(spannedString.substring(start, end), textTransform)
+        val spanString = getTransformText(spannedString.substring(start, end), linkTextTransform)
         spannedString = spannedString.replaceRange(start, end, spanString)
         when (span) {
             is RelativeSizeSpan -> span.spanStyle(fontSize)

--- a/roktux/src/test/assets/TextComponent/RichText_with_text_transformation.json
+++ b/roktux/src/test/assets/TextComponent/RichText_with_text_transformation.json
@@ -1,0 +1,28 @@
+{
+  "type": "RichText",
+  "node": {
+    "value": "powered by <a target=\"_blank\" href=\"https://rokt.com\">Rokt</a> - <a target=\"_blank\" href=\"https://rokt.com/privacy-policy/\">Privacy Policy</a>",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "text": {
+                "textTransform": "capitalize"
+              }
+            }
+          }
+        ],
+        "link": [
+          {
+            "default": {
+              "text": {
+                "textTransform": "uppercase"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/TextComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/TextComponentTest.kt
@@ -1,5 +1,6 @@
 package com.rokt.roktux.component
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -285,6 +286,51 @@ class TextComponentTest : BaseDcuiEspressoTest() {
             .assertTextEquals("CLICK HERE")
             .assertLinkFontSize(16)
             .assertLinkTextColor("#FF3700B3")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "TextComponent/RichText_with_text_transformation.json")
+    fun testRichTextComponentTextTransformation() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertTextEquals("Powered By ROKT - PRIVACY POLICY")
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "TextComponent/RichText_with_text_transformation.json")
+    fun testRichTextComponentLinkClickEvent() {
+        // Click on 'ROKT' link
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertExists()
+            .performTouchInput { click(position = Offset(10f, 10f)) }
+
+        Assert.assertTrue(
+            getCapturedEvents().stream()
+                .anyMatch { e ->
+                    e.equals(
+                        LayoutContract.LayoutEvent.UrlSelected(
+                            "https://rokt.com",
+                            OpenLinks.Externally,
+                        ),
+                    )
+                },
+        )
+
+        // Click on 'PRIVACY POLICY' link
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertExists()
+            .performTouchInput { click(position = centerRight) }
+
+        Assert.assertTrue(
+            getCapturedEvents().stream()
+                .anyMatch { e ->
+                    e.equals(
+                        LayoutContract.LayoutEvent.UrlSelected(
+                            "https://rokt.com/privacy-policy/",
+                            OpenLinks.Externally,
+                        ),
+                    )
+                },
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The ModifierFactory was performing the transformation on the whole text including the html text. When the href url is transformed to caps, it fails to open in the browser.

Fixes [LAYOUT-2319](https://rokt.atlassian.net/browse/LAYOUT-2319)

### What Has Changed

-   Updated `applyTextProperties` to apply text transformation only when it is not `RichTextComponent`
-   Modified `RichTextComponent` to handle text transformations for html texts including link spans.
-   Added a test case to verify the text transformation functionality.
-   Added test cases to verify link click events.
-   Updated CHANGELOG with fix details.

### How Has This Been Tested?

Added unit tests. Tested locally

### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
