### PR TITLE
NOJIRA Remove Reflection Usage from TypedKey

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,6 @@ coil-kt-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
 coil-test = { group = "io.coil-kt", name = "coil-test", version.ref = "coil" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 junit-params = { group = "pl.pragmatists", name = "JUnitParams", version.ref = "junitParams" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }

--- a/modelmapper/build.gradle.kts
+++ b/modelmapper/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.foundation)
-    implementation(libs.kotlin.reflect)
     testApi(libs.bundles.mockk)
     testImplementation(libs.junit4)
     testImplementation(libs.junit.params)

--- a/modelmapper/src/main/java/com/rokt/modelmapper/hmap/TypedKey.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/hmap/TypedKey.kt
@@ -16,12 +16,7 @@ package com.rokt.modelmapper.hmap
 class TypedKey<T> @PublishedApi internal constructor(val type: Class<out T>, val key: String) {
 
     companion object {
-        inline operator fun <reified T : Any> invoke(key: String): TypedKey<T> {
-            if (T::class.typeParameters.isNotEmpty()) {
-                throw IllegalArgumentException("Value type cannot have type parameters")
-            }
-            return TypedKey(T::class.java, key)
-        }
+        inline operator fun <reified T : Any> invoke(key: String): TypedKey<T> = TypedKey(T::class.java, key)
     }
 
     override fun hashCode(): Int {

--- a/modelmapper/src/test/java/com/rokt/modelmapper/hmap/TypedKeyTest.kt
+++ b/modelmapper/src/test/java/com/rokt/modelmapper/hmap/TypedKeyTest.kt
@@ -1,17 +1,9 @@
 package com.rokt.modelmapper.hmap
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class TypedKeyTest {
-
-    @Test
-    fun `invoke with parameterized type throws exception`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            TypedKey<List<String>>("key")
-        }
-    }
 
     @Test
     fun `invocation with key sets key`() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The usage of reflection here was to ensure that fast-fail if someone were to inadvertently use a parameterised valued type as a value in `TypedKey`. Unfortunately the `typeParameters` method is not working when running via .NET MAUI and no attempts at adding proguard rules fixed it.

Since this check is more of a nice to have (since either way it will eventually throw an exception if used), this PR just removes it. The javadoc still mentions its an unsupported use-case.

Fixes NO-JIRA

### What Has Changed

- Removed the parameterised type check
- Removed the reflection library as this was the only usage

### How Has This Been Tested?

- After removing it and publishing locally MAUI was able to work

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
