### PR TITLE
NOJIRA - Always generate snapshot, update Android SDK on release

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -12,8 +12,9 @@ jobs:
   setup-and-version:
     runs-on: ubuntu-latest
     outputs:
-      final_version: ${{ steps.final-version.outputs.final-version }}
-      version_changed: ${{ steps.version-changed.outputs.any_changed }}
+      full_release_needed: ${{ steps.version-changed.outputs.any_changed }}
+      full_release_version: ${{ steps.version-file.outputs.release-version }}
+      next_snapshot_version: ${{ steps.next-version.outputs.next-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,21 +30,16 @@ jobs:
           echo "release-version=$version_from_file" >> $GITHUB_OUTPUT
       - name: Bump version if necessary
         id: bump-semver
-        if: steps.version-changed.outputs.any_changed == 'false'
         uses: actions-ecosystem/action-bump-semver@34e334551143a5301f38c830e44a22273c6ff5c5 # v1.0.0
         with:
           current_version: ${{ steps.version-file.outputs.release-version }}
           level: minor
-      - name: Determine final version
-        id: final-version
+      - name: Determine next snapshot version
+        id: next-version
         run: |
-          if [[ "${{ steps.version-changed.outputs.any_changed }}" == "true" ]]; then
-            echo "final-version=${{ steps.version-file.outputs.release-version }}" >> $GITHUB_OUTPUT
-          else
-            echo "final-version=${{ steps.bump-semver.outputs.new_version }}-SNAPSHOT" >> $GITHUB_OUTPUT
-          fi
+          echo "next-version=${{ steps.bump-semver.outputs.new_version }}-SNAPSHOT" >> $GITHUB_OUTPUT
 
-  build-and-release:
+  generate-next-snapshot:
     needs: setup-and-version
     runs-on: ubuntu-latest
     env:
@@ -59,9 +55,30 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
       - name: Publish to Maven local
-        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }}
+        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.next_snapshot_version }}
       - name: Publish to Maven Central
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} --no-configuration-cache
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.next_snapshot_version }} --no-configuration-cache
+
+  build-full-release:
+    needs: setup-and-version
+    if: needs.setup-and-version.outputs.full_release_needed == 'true'
+    runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup JDK
+        uses: ./.github/actions/setup-java
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
+      - name: Publish to Maven local
+        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.full_release_version }}
+      - name: Publish to Maven Central
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.full_release_version }} --no-configuration-cache
 
       - name: Find release AAR Files
         id: find-aar
@@ -77,7 +94,7 @@ jobs:
           for file in "${aar_files[@]}"; do
             dir=$(dirname "$file")
             base=$(basename "$file" -release.aar)
-            new_file="$dir/$base-${{ needs.setup-and-version.outputs.final_version }}.aar"
+            new_file="$dir/$base-${{ needs.setup-and-version.outputs.full_release_version }}.aar"
             mv "$file" "$new_file"
             new_files+=("$new_file")
           done
@@ -99,7 +116,7 @@ jobs:
       - name: Rename POM files
         id: rename-pom
         run: |
-          RELEASE_VERSION=${{ needs.setup-and-version.outputs.final_version }}
+          RELEASE_VERSION=${{ needs.setup-and-version.outputs.full_release_version }}
           POM_FILES=${{ steps.find-pom.outputs.pom_files }}
           IFS="," read -r -a FILES <<< "$POM_FILES"
           RENAMED_FILES=()
@@ -134,11 +151,57 @@ jobs:
 
       - name: Create Github release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        if: needs.setup-and-version.outputs.version_changed == 'true'
         with:
           artifacts: ${{ steps.concat-files.outputs.concatenated_files }}
           makeLatest: true
-          tag: ${{ needs.setup-and-version.outputs.final_version }}
+          tag: ${{ needs.setup-and-version.outputs.full_release_version }}
           body: |
             ## Release notes:
             ${{ steps.extract-release-notes.outputs.release_notes }}
+
+  update-android-sdk:
+    needs: [generate-next-snapshot, setup-and-version]
+    if: needs.setup-and-version.outputs.full_release_needed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        with:
+          app-id: ${{ secrets.SDK_RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.SDK_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            sdk-android-source
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROKT/sdk-android-source
+          token: ${{ steps.generate-token.outputs.token }}
+          path: sdk-android-source
+          ref: main
+          persist-credentials: false
+
+      - name: Update Rokt Android SDK's UX Helper version
+        uses: colathro/toml-editor@da6b46ee7779ed730d2160393ed95fb20e82696d # v1.1.1
+        with:
+          file: "gradle/libs.versions.toml"
+          key: "versions.roktUxHelper"
+          value: ${{ needs.setup-and-version.outputs.next_snapshot_version }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: Update UX Helper to ${{ needs.setup-and-version.outputs.next_snapshot_version }}
+          branch: update-ux-helper-${{ needs.setup-and-version.outputs.next_snapshot_version }}
+          title: NOJIRA - Bump UX Helper to ${{ needs.setup-and-version.outputs.next_snapshot_version }}
+          base: main
+          body: |
+            # Update UX Helper
+
+            Rokt UX Helper version ${{ needs.setup-and-version.outputs.full_release_version }} has been released.
+
+            Bumping UX Helper to next snapshot version ${{ needs.setup-and-version.outputs.next_snapshot_version }}.
+          labels: |
+            chore

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -54,8 +54,6 @@ jobs:
         uses: ./.github/actions/setup-java
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
-      - name: Publish to Maven local
-        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.next_snapshot_version }}
       - name: Publish to Maven Central
         run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.next_snapshot_version }} --no-configuration-cache
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Update the release workflow to always make snapshots for the next available version and update the Android SDK when a UX Helper release is made

### What Has Changed

- Release workflow

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
