### PR TITLE
LAYOUT-2339 - Fix the component stretch behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed html links not opening when textTransformation is set to upper case
+- Component stretch behaviour not being applied
 
 ## [0.5.0] - 2025-04-02
 

--- a/roktux/src/main/java/com/rokt/roktux/component/ColumnComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/ColumnComponent.kt
@@ -2,6 +2,7 @@ package com.rokt.roktux.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -83,16 +84,20 @@ internal class ColumnComponent(
                         containerProperties = nonWhenChild.containerProperties,
                         index = breakpointIndex,
                         isPressed = isPressed,
-                    ).also { container ->
-                        container.weight?.let {
+                    ).also { childContainer ->
+                        childContainer.weight?.let {
                             childModifier = childModifier.then(Modifier.weight(it))
                         }
-                        container.selfAlignmentBias?.let {
+                        childContainer.selfAlignmentBias?.let {
                             if (it == AlignmentUiModel.Stretch.bias) {
                                 anyStretchChild = true
+                                childModifier = childModifier.then(Modifier.fillMaxWidth())
                             } else {
                                 childModifier = childModifier.then(Modifier.align(BiasAlignment.Horizontal(it)))
                             }
+                        }
+                        if (container.alignmentBias == AlignmentUiModel.Stretch.bias) {
+                            childModifier = childModifier.then(Modifier.fillMaxWidth())
                         }
                     }
                     factory.CreateComposable(

--- a/roktux/src/main/java/com/rokt/roktux/component/RowComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/RowComponent.kt
@@ -3,6 +3,7 @@ package com.rokt.roktux.component
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
@@ -80,16 +81,20 @@ internal class RowComponent(private val factory: LayoutUiModelFactory, private v
                         containerProperties = nonWhenChild.containerProperties,
                         index = breakpointIndex,
                         isPressed = isPressed,
-                    ).also { container ->
-                        container.weight?.let {
+                    ).also { childContainer ->
+                        childContainer.weight?.let {
                             childModifier = childModifier.then(Modifier.weight(it))
                         }
-                        container.selfAlignmentBias?.let {
+                        childContainer.selfAlignmentBias?.let {
                             if (it == AlignmentUiModel.Stretch.bias) {
                                 anyStretchChild = true
+                                childModifier = childModifier.then(Modifier.fillMaxHeight())
                             } else {
                                 childModifier = childModifier.then(Modifier.align(BiasAlignment.Vertical(it)))
                             }
+                        }
+                        if (container.alignmentBias == AlignmentUiModel.Stretch.bias) {
+                            childModifier = childModifier.then(Modifier.fillMaxHeight())
                         }
                     }
                     factory.CreateComposable(

--- a/roktux/src/test/assets/ColumnComponent/Column_with_StretchAlignment.json
+++ b/roktux/src/test/assets/ColumnComponent/Column_with_StretchAlignment.json
@@ -6,6 +6,9 @@
         "own": [
           {
             "default": {
+              "dimension": {
+                "maxWidth": 200
+              },
               "container": {
                 "alignItems": "stretch"
               }
@@ -18,23 +21,45 @@
       {
         "type": "BasicText",
         "node": {
-          "value": "Test Offer",
           "styles": {
             "elements": {
-              "own": []
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "minWidth": 100
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
+                }
+              ]
             }
-          }
+          },
+          "value": "Child1"
         }
       },
       {
         "type": "BasicText",
         "node": {
-          "value": "Long Offer with multiple test in it to verify the height",
           "styles": {
             "elements": {
-              "own": []
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "minWidth": 200
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
+                }
+              ]
             }
-          }
+          },
+          "value": "Child2"
         }
       }
     ]

--- a/roktux/src/test/assets/ColumnComponent/Column_with_StretchAlignment_child.json
+++ b/roktux/src/test/assets/ColumnComponent/Column_with_StretchAlignment_child.json
@@ -6,8 +6,8 @@
         "own": [
           {
             "default": {
-              "container": {
-                "alignItems": "stretch"
+              "dimension": {
+                "maxWidth": 200
               }
             }
           }
@@ -16,53 +16,48 @@
     },
     "children": [
       {
-        "type": "When",
+        "type": "BasicText",
         "node": {
-          "predicates": [
-            {
-              "type": "StaticBoolean",
-              "predicate": {
-                "value": true,
-                "condition": "is-true"
-              }
-            }
-          ],
-          "children": [
-            {
-              "type": "BasicText",
-              "node": {
-                "value": "Test Offer",
-                "styles": {
-                  "elements": {
-                    "own": [
-                      {
-                        "default": {
-                          "flexChild": {
-                            "alignSelf": "stretch"
-                          }
-                        }
-                      }
-                    ]
+          "styles": {
+            "elements": {
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "minWidth": 100
+                    },
+                    "flexChild": {
+                      "weight": 1,
+                      "alignSelf": "stretch"
+                    }
                   }
                 }
-              }
+              ]
             }
-          ]
+          },
+          "value": "Child1"
         }
       },
       {
         "type": "BasicText",
         "node": {
-          "value": "Long Offer with multiple test in it to verify the height",
           "styles": {
             "elements": {
               "own": [
                 {
-                  "default": {}
+                  "default": {
+                    "dimension": {
+                      "minWidth": 200
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
                 }
               ]
             }
-          }
+          },
+          "value": "Child2"
         }
       }
     ]

--- a/roktux/src/test/assets/RowComponent/Row_with_StretchAlignment.json
+++ b/roktux/src/test/assets/RowComponent/Row_with_StretchAlignment.json
@@ -6,6 +6,9 @@
         "own": [
           {
             "default": {
+              "dimension": {
+                "maxHeight": 200
+              },
               "container": {
                 "alignItems": "stretch"
               }
@@ -18,27 +21,45 @@
       {
         "type": "BasicText",
         "node": {
-          "value": "Test Offer",
           "styles": {
             "elements": {
               "own": [
                 {
-                  "default": {}
+                  "default": {
+                    "dimension": {
+                      "minHeight": 100
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
                 }
               ]
             }
-          }
+          },
+          "value": "Child1"
         }
       },
       {
         "type": "BasicText",
         "node": {
-          "value": "Long Offer with multiple test in it to verify the height",
           "styles": {
             "elements": {
-              "own": []
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "minHeight": 200
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
+                }
+              ]
             }
-          }
+          },
+          "value": "Child2"
         }
       }
     ]

--- a/roktux/src/test/assets/RowComponent/Row_with_StretchAlignment_child.json
+++ b/roktux/src/test/assets/RowComponent/Row_with_StretchAlignment_child.json
@@ -3,38 +3,61 @@
   "node": {
     "styles": {
       "elements": {
-        "own": []
+        "own": [
+          {
+            "default": {
+              "dimension": {
+                "maxHeight": 200
+              }
+            }
+          }
+        ]
       }
     },
     "children": [
       {
         "type": "BasicText",
         "node": {
-          "value": "Long Offer with multiple test in it to verify the height",
-          "styles": {
-            "elements": {
-              "own": []
-            }
-          }
-        }
-      },
-      {
-        "type": "BasicText",
-        "node": {
-          "value": "Test Offer",
           "styles": {
             "elements": {
               "own": [
                 {
                   "default": {
+                    "dimension": {
+                      "minHeight": 100
+                    },
                     "flexChild": {
+                      "weight": 1,
                       "alignSelf": "stretch"
                     }
                   }
                 }
               ]
             }
-          }
+          },
+          "value": "Child1"
+        }
+      },
+      {
+        "type": "BasicText",
+        "node": {
+          "styles": {
+            "elements": {
+              "own": [
+                {
+                  "default": {
+                    "dimension": {
+                      "minHeight": 200
+                    },
+                    "flexChild": {
+                      "weight": 1
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "value": "Child2"
         }
       }
     ]

--- a/roktux/src/test/java/com/rokt/roktux/component/ColumnComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/ColumnComponentTest.kt
@@ -102,6 +102,25 @@ class ColumnComponentTest : BaseDcuiEspressoTest() {
     }
 
     @Test
+    @DcuiNodeJson(jsonFile = "ColumnComponent/Column_with_StretchAlignment.json")
+    fun testColumnComponentWithStretchAlignment() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed()
+        val childRect1 = composeTestRule.onNodeWithText("Child1").fetchSemanticsNode().boundsInRoot
+        val childRect2 = composeTestRule.onNodeWithText("Child2").fetchSemanticsNode().boundsInRoot
+        assertEquals(childRect1.width, childRect2.width)
+        assertEquals(200.dp, childRect1.width.dp)
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "ColumnComponent/Column_with_StretchAlignment_child.json")
+    fun testColumnComponentWithStretchAlignmentChild() {
+        val childRect1 = composeTestRule.onNodeWithText("Child1").fetchSemanticsNode().boundsInRoot
+        val childRect2 = composeTestRule.onNodeWithText("Child2").fetchSemanticsNode().boundsInRoot
+        assertEquals(childRect1.width, childRect2.width)
+        assertEquals(200.dp, childRect1.width.dp)
+    }
+
+    @Test
     @DcuiNodeJson(jsonFile = "ColumnComponent/Column_with_Padding.json")
     fun testColumnComponentWithPadding() {
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)

--- a/roktux/src/test/java/com/rokt/roktux/component/RowComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/RowComponentTest.kt
@@ -141,20 +141,19 @@ class RowComponentTest : BaseDcuiEspressoTest() {
     @DcuiNodeJson(jsonFile = "RowComponent/Row_with_StretchAlignment.json")
     fun testRowComponentWithStretchAlignment() {
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed()
-        val childRect1 = composeTestRule.onNodeWithText("Test Offer").fetchSemanticsNode().boundsInRoot
-        val childRect2 = composeTestRule.onNodeWithText("Long Offer with multiple test in it to verify the height")
-            .fetchSemanticsNode().boundsInRoot
+        val childRect1 = composeTestRule.onNodeWithText("Child1").fetchSemanticsNode().boundsInRoot
+        val childRect2 = composeTestRule.onNodeWithText("Child2").fetchSemanticsNode().boundsInRoot
         assertEquals(childRect1.height, childRect2.height)
+        assertEquals(200.dp, childRect1.height.dp)
     }
 
     @Test
     @DcuiNodeJson(jsonFile = "RowComponent/Row_with_StretchAlignment_child.json")
     fun testRowComponentWithStretchAlignmentChild() {
-        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed()
-        val childRect1 = composeTestRule.onNodeWithText("Test Offer").fetchSemanticsNode().boundsInRoot
-        val childRect2 = composeTestRule.onNodeWithText("Long Offer with multiple test in it to verify the height")
-            .fetchSemanticsNode().boundsInRoot
+        val childRect1 = composeTestRule.onNodeWithText("Child1").fetchSemanticsNode().boundsInRoot
+        val childRect2 = composeTestRule.onNodeWithText("Child2").fetchSemanticsNode().boundsInRoot
         assertEquals(childRect1.height, childRect2.height)
+        assertEquals(200.dp, childRect1.height.dp)
     }
 
     @Test


### PR DESCRIPTION
### Background

Fix the stretch behaviour when the components are arranged in a Row/Column and the container stretch or alignSelf stretch properties are set

Fixes [LAYOUT-2339](https://rokt.atlassian.net/browse/LAYOUT-2339)

### What Has Changed

* When the container stretch is set, apply the intrinsic size and use the max height/width available.
* Use `fillMaxWidth` for column and `fillMaxHeight` for row when stretch is set.
* Added unit tests

### How Has This Been Tested?
Added unit tests to verify the changes
Used mock json to test the behaviour.

| Before                                                                                                                                                                                                                                     | After                                                                                                                                                                                                                                     |
| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![Screenshot_20250411_131256](https://github.com/user-attachments/assets/032b6474-2ea9-4885-ad02-724e6f382a2d) | ![Screenshot_20250411_131201](https://github.com/user-attachments/assets/0a2a1d09-6add-4ad7-9910-bdb25a60e37c) |

### Notes


### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
