### PR TITLE
SQDSDKS-7308 - Add support for `ExternalPaymentTrigger` in Response Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support new response action type `ExternalPaymentTrigger`
+
 ### Fixed
 
 - Fixed html links not opening when textTransformation is set to upper case

--- a/modelmapper/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
@@ -201,6 +201,7 @@ class ExperienceModelMapperImpl(private val experienceResponse: String, private 
     private fun NetworkAction.toActionModel(): Action = when (this) {
         NetworkAction.Url -> Action.Url
         NetworkAction.CaptureOnly -> Action.CaptureOnly
+        NetworkAction.ExternalPaymentTrigger -> Action.ExternalPaymentTrigger
     }
 
     private fun NetworkSignalType.toSignalTypeModel(): SignalType = when (this) {

--- a/modelmapper/src/main/java/com/rokt/modelmapper/model/NetworkAction.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/model/NetworkAction.kt
@@ -10,4 +10,7 @@ enum class NetworkAction {
 
     @SerialName("CaptureOnly")
     CaptureOnly,
+
+    @SerialName("ExternalPaymentTrigger")
+    ExternalPaymentTrigger,
 }

--- a/modelmapper/src/main/java/com/rokt/modelmapper/uimodel/ExperienceModel.kt
+++ b/modelmapper/src/main/java/com/rokt/modelmapper/uimodel/ExperienceModel.kt
@@ -77,6 +77,7 @@ enum class Action {
     Url,
 
     CaptureOnly,
+    ExternalPaymentTrigger,
 }
 
 enum class SignalType {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Add support for new Action type in Creative response object.

Fixes [SQDSDKS-7308](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7308)

### What Has Changed

* Add new enum item for `NetworkAction`. Added `ExternalPaymentTrigger`
* Updated mappers

### How Has This Been Tested?

Tested locally with mock json

### Notes


### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
