### PR TITLE
feat: Add support for fallback image keys in data binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fallback `imageKey` support in `DataImage` and `DataImageCarousel` nodes
+
 ## [0.6.0] - 2025-05-28
 
 ### Added

--- a/modelmapper/src/test/java/com/rokt/modelmapper/data/DataBindingTest.kt
+++ b/modelmapper/src/test/java/com/rokt/modelmapper/data/DataBindingTest.kt
@@ -293,6 +293,116 @@ class DataBindingImplTest : MockkUnitTest() {
     }
 
     @Test
+    fun `when bind model is called for OfferImageModel with multiple keys, it should return the first valid one`() {
+        // Act
+        val value =
+            bindModel<OfferImageModel>(
+                "invalidKey|creativeCarouselImageVertical.3",
+                offerModel = offer,
+            )
+
+        // Assert
+        assertThat(value, `is`(notNullValue()))
+        assertThat(value, `is`(instanceOf(OfferImageModel::class.java)))
+        assertThat((value as OfferImageModel).properties[TypedKey<String>("title")], `is`("creativeImage 3 !!!"))
+    }
+
+    @Test
+    fun `when bind model is called for OfferImageModel with multiple keys with spaces, it should return the first valid one`() {
+        // Act
+        val value =
+            bindModel<OfferImageModel>(
+                " invalidKey | creativeCarouselImageVertical.3 ",
+                offerModel = offer,
+            )
+
+        // Assert
+        assertThat(value, `is`(notNullValue()))
+        assertThat(value, `is`(instanceOf(OfferImageModel::class.java)))
+        assertThat((value as OfferImageModel).properties[TypedKey<String>("title")], `is`("creativeImage 3 !!!"))
+    }
+
+    @Test
+    fun `when bind model is called for OfferImageModel with multiple keys, and none of them matches, it should return null`() {
+        // Act
+        val value =
+            bindModel<OfferImageModel>(
+                "invalidKey|anotherInvalidKey",
+                offerModel = offer,
+            )
+
+        // Assert
+        assertThat(value, `is`(nullValue()))
+    }
+
+    @Test
+    fun `when bind model is called for OfferImageModel and AddToCart module with multiple keys, it should return the first valid one`() {
+        // Act
+        val value =
+            bindModel<OfferImageModel>(
+                "invalidKey|catalogItemImage1",
+                offerModel = offer,
+                module = Module.AddToCart,
+                itemIndex = 0,
+            )
+
+        // Assert
+        assertThat(value, `is`(notNullValue()))
+        assertThat(value, `is`(instanceOf(OfferImageModel::class.java)))
+        assertThat((value as OfferImageModel).properties[TypedKey<String>("title")], `is`("title1"))
+    }
+
+    @Test
+    fun `when getOfferImages is called with a valid prefix, it should return matching images`() {
+        // Act
+        val result = getOfferImages("creativeCarouselImageHorizontal", offer)
+
+        // Assert
+        assertThat(result.size, `is`(1))
+        assertThat(result.containsKey(1), `is`(true))
+        assertThat(result[1]?.properties?.get(TypedKey<String>("title")), `is`("creativeImage 1 !!!"))
+    }
+
+    @Test
+    fun `when getOfferImages is called with multiple prefixes, it should return matching images`() {
+        // Act
+        val result = getOfferImages("invalidKey|creativeCarouselImageVertical", offer)
+
+        // Assert
+        assertThat(result.size, `is`(1))
+        assertThat(result.containsKey(1), `is`(true))
+        assertThat(result[1]?.properties?.get(TypedKey<String>("title")), `is`("creativeImage 1 !!!"))
+    }
+
+    @Test
+    fun `when getOfferImages is called with prefixes with spaces, it should trim them and return matching images`() {
+        // Act
+        val result = getOfferImages(" invalidKey | creativeCarouselImageVertical ", offer)
+
+        // Assert
+        assertThat(result.size, `is`(1))
+        assertThat(result.containsKey(1), `is`(true))
+    }
+
+    @Test
+    fun `when getOfferImages is called with an invalid prefix, it should return an empty map`() {
+        // Act
+        val result = getOfferImages("invalidPrefix", offer)
+
+        // Assert
+        assertThat(result.isEmpty(), `is`(true))
+    }
+
+    @Test
+    fun `when getOfferImages is called with a null offer, it should return an empty map`() {
+        // Act
+        val result = getOfferImages("creativeCarouselImageHorizontal", null)
+
+        // Assert
+        assertThat(result.isEmpty(), `is`(true))
+    }
+
+    @Test
     @Parameters(method = "getDataBindingParameters")
     fun testDataValueBinding(input: String, output: String, contextKey: String?, clazz: Class<*>, itemIndex: Int = 0) {
         println("$input $output $contextKey $clazz")

--- a/roktux/src/test/assets/DataImageCarouselComponent/DataImageCarousel_Fallback_ImageKey.json
+++ b/roktux/src/test/assets/DataImageCarouselComponent/DataImageCarousel_Fallback_ImageKey.json
@@ -1,0 +1,37 @@
+{
+  "type": "DataImageCarousel",
+  "node": {
+    "imageKey": "unavailableKey | creativeCarouselImageVertical",
+    "duration": 4000,
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "background": {
+                "backgroundColor": {
+                  "light": "#d51a1a",
+                  "dark": "#cdcdcd"
+                }
+              },
+              "dimension": {
+                "minWidth": 0,
+                "width": {
+                  "type": "fixed",
+                  "value": 150
+                },
+                "height": {
+                  "type": "fixed",
+                  "value": 180
+                }
+              }
+            }
+          }
+        ],
+        "indicator": [],
+        "seenIndicator": [],
+        "progressIndicatorContainer": []
+      }
+    }
+  }
+}

--- a/roktux/src/test/assets/DataImageComponent/DataImage_with_FallbackImageKey.json
+++ b/roktux/src/test/assets/DataImageComponent/DataImage_with_FallbackImageKey.json
@@ -1,0 +1,26 @@
+{
+  "type": "DataImage",
+  "node": {
+    "imageKey": "invalidImageKey | anotherInvalidImageKey | creativeImage",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "dimension": {
+                "width": {
+                  "type": "fixed",
+                  "value": 150
+                },
+                "height": {
+                  "type": "fixed",
+                  "value": 150
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/assets/DataImageComponent/DataImage_with_InvalidImageKey.json
+++ b/roktux/src/test/assets/DataImageComponent/DataImage_with_InvalidImageKey.json
@@ -1,0 +1,26 @@
+{
+  "type": "DataImage",
+  "node": {
+    "imageKey": "unavailableKey",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "dimension": {
+                "width": {
+                  "type": "fixed",
+                  "value": 150
+                },
+                "height": {
+                  "type": "fixed",
+                  "value": 150
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/assets/DataImageComponent/DataImage_with_ValidImageKey.json
+++ b/roktux/src/test/assets/DataImageComponent/DataImage_with_ValidImageKey.json
@@ -1,0 +1,26 @@
+{
+  "type": "DataImage",
+  "node": {
+    "imageKey": "creativeImage",
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "dimension": {
+                "width": {
+                  "type": "fixed",
+                  "value": 150
+                },
+                "height": {
+                  "type": "fixed",
+                  "value": 150
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/DataImageCarouselComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/DataImageCarouselComponentTest.kt
@@ -117,4 +117,13 @@ class DataImageCarouselComponentTest : BaseDcuiEspressoTest() {
         assertNotEquals(childRect.topLeft, Offset.Zero)
         assertEquals(childRect.bottom, parentRect.bottom)
     }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "DataImageCarouselComponent/DataImageCarousel_Fallback_ImageKey.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_image_carousel_key.json")
+    fun testDataImageCarouselComponentWithFallbackImageKey() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed().assertHeightIsEqualTo(180.dp)
+            .assertWidthIsEqualTo(150.dp).assertBackgroundColor("#d51a1a")
+    }
 }

--- a/roktux/src/test/java/com/rokt/roktux/component/DataImageComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/DataImageComponentTest.kt
@@ -1,0 +1,44 @@
+package com.rokt.roktux.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
+import com.rokt.core.testutils.annotations.DcuiConfig
+import com.rokt.core.testutils.annotations.DcuiNodeJson
+import com.rokt.core.testutils.annotations.DcuiOfferJson
+import com.rokt.roktux.testutil.BaseDcuiEspressoTest
+import org.junit.runner.RunWith
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+class DataImageComponentTest : BaseDcuiEspressoTest() {
+
+    @Test
+    @DcuiNodeJson(jsonFile = "DataImageComponent/DataImage_with_InvalidImageKey.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_valid_key.json")
+    fun testDataImageComponentWithUnavailableKey() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "DataImageComponent/DataImage_with_ValidImageKey.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_valid_key.json")
+    fun testDataImageComponentWithValidKey() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "DataImageComponent/DataImage_with_FallbackImageKey.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_valid_key.json")
+    fun testDataImageComponentWithFallbackKey() {
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG)
+            .assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Add data binding logic for `DataImage` and `DataImageCarousel` components to support fallback mechanism 
Support `|` separated keys and lookup in the creativeImages for the matching ones

Fixes [SQDSDKS-7516](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7516)

### What Has Changed

- Add data binding logic for `DataImage` and `DataImageCarousel` components to support fallback mechanism 
- Support `|` separated keys and lookup in the creativeImages for the matching ones

### How Has This Been Tested?

Tested locally.
Added unit tests and UI tests

### Notes


### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
