### PR TITLE
chore: Allow for skip sign when publishing

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/rokt/roktux/MavenCentralPublish.kt
+++ b/build-logic/convention/src/main/kotlin/com/rokt/roktux/MavenCentralPublish.kt
@@ -6,6 +6,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Project
 
 fun Project.configureMavenPublishing(roktMavenPublish: RoktMavenPublishExtension) {
+    val shouldSkipSign = project.findProperty("SKIP_SIGN")?.toString() == "true"
+
     extensions.configure<MavenPublishBaseExtension>("mavenPublishing") {
         afterEvaluate {
             publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
@@ -14,7 +16,13 @@ fun Project.configureMavenPublishing(roktMavenPublish: RoktMavenPublishExtension
                 groupId = roktMavenPublish.groupId.get(),
                 version = roktMavenPublish.version.get(),
             )
-            signAllPublications()
+
+            if (!shouldSkipSign) {
+                signAllPublications()
+            } else {
+                println("Skip signAllPublications")
+            }
+
             pom {
                 name.set(roktMavenPublish.artifactId.get())
                 description.set(roktMavenPublish.description.get())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Replicates the functionality of the core Rokt SDK and allows for signing to be skipped when publishing to Maven to aid in local development

### What Has Changed

- Maven publish

### How Has This Been Tested?

- Ran `./gradlew publishMavenPublicationToMavenLocal -PVERSION=4.1337.0-SNAPSHOT -PSKIP_SIGN=true`

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
- [X] New and existing unit tests pass locally with my changes.
