### PR TITLE
fix: Bump com.android.tools:desugar_jdk_libs from 1.2.0 to 2.1.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 androidGradlePlugin = "8.6.1"
-androidDesugarJdkLibs = "1.2.0"
+androidDesugarJdkLibs = "2.1.5"
 androidxActivity = "1.10.1"
 androidxAppCompat = "1.7.1"
 androidxComposeBom = "2024.09.02"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Compile SDK version 35 needs the `desugar_jdk_libs` to be updated.

### What Has Changed

Updated com.android.tools:desugar_jdk_libs from 1.2.0 to 2.1.5
<img width="1023" height="70" alt="Screenshot 2025-09-10 at 1 10 49 pm" src="https://github.com/user-attachments/assets/dca4d11a-bca9-4988-9d23-5384469d27d0" />


### How Has This Been Tested?

Built and tested locally

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
