### PR TITLE
fix: Re-initialize RoktLayout when a new ViewModel is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed CarouselDistribution pages filling screen when using fit-height
+- Fix `RoktLayout` recomposition when ViewModel is changed
 
 ## [0.7.0] - 2025-08-18
 

--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -338,7 +338,7 @@ private fun RoktLayout(
             }
         }
     }
-    LaunchedEffect(key1 = Unit) {
+    LaunchedEffect(key1 = viewModel) {
         viewModel.setEvent(LayoutContract.LayoutEvent.LayoutInitialised)
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The issue happens when a second Layout call happens with the same parent view 

Fixes [SDKE-225](https://rokt.atlassian.net/browse/SDKE-225)

### What Has Changed

The `LaunchedEffect` in `RoktLayout` is updated to re-trigger the `LayoutInitialised` event whenever the `viewModel` instance changes. This ensures that the layout correctly initializes with the new ViewModel's state.

### How Has This Been Tested?

Tested locally in the test app.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
