### PR TITLE
fix: pin reusable workflow references to commit SHAs

### DIFF
--- a/.github/workflows/maintenance-trunk-upgrade.yml
+++ b/.github/workflows/maintenance-trunk-upgrade.yml
@@ -29,7 +29,7 @@ jobs:
   trunk-upgrade:
     needs: generate-and-call-upgrade
     name: Run trunk upgrade
-    uses: ROKT/rokt-workflows/.github/workflows/trunk-upgrade.yml@main
+    uses: ROKT/rokt-workflows/.github/workflows/trunk-upgrade.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     with:
       token: ${{ needs.generate-and-call-upgrade.outputs.generated-token }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -121,6 +121,6 @@ jobs:
       github.event.pull_request.draft == false
     needs: [trunk-check, lint, unit-test, assemble-debug, snapshot-test]
     name: Notify GChat
-    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@main
+    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     secrets:
       gchat_webhook: ${{ secrets.GCHAT_PRS_MOBILE_INTEGRATION_CHANNEL_WEBHOOK }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate changelog from git history
         id: changelog
-        uses: ROKT/rokt-workflows/actions/generate-changelog@main
+        uses: ROKT/rokt-workflows/actions/generate-changelog@1859338d7c2c2b873233505c751acbf09fb218d5 # main
         with:
           version: ${{ steps.bump-version.outputs.new_version }}
       - name: Publish to Maven local


### PR DESCRIPTION
## Summary
- Pin ROKT/rokt-workflows references to commit SHAs
- Addresses **3 unpinned-uses** findings from zizmor security audit

## Rollback plan
Revert this PR.