### PR TITLE
fix: harden GitHub Actions workflows and add zizmor CI check

### DIFF
--- a/.github/workflows/maintenance-trunk-upgrade.yml
+++ b/.github/workflows/maintenance-trunk-upgrade.yml
@@ -38,7 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup JDK
         uses: ./.github/actions/setup-java
       - name: Setup Gradle
@@ -49,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup JDK
         uses: ./.github/actions/setup-java
       - name: Setup Gradle
@@ -68,6 +74,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup JDK
         uses: ./.github/actions/setup-java
       - name: Setup Gradle
@@ -90,6 +98,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
         uses: ./.github/actions/setup-java

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check if VERSION file changed
         id: version-changed
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
@@ -50,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup JDK
         uses: ./.github/actions/setup-java
       - name: Setup Gradle
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup JDK
         uses: ./.github/actions/setup-java
       - name: Setup Gradle

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install zizmor
+        run: pipx install zizmor==1.23.1
+      # continue-on-error: true until pre-existing findings are resolved.
+      # Once triaged, remove this flag to make zizmor a hard blocker.
+      - name: Run zizmor
+        continue-on-error: true
+        run: zizmor --format plain .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,6 +3,8 @@ name: Zizmor Security Scan
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
     paths:
       - .github/workflows/**
       - .github/actions/**
@@ -26,10 +28,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 1
       - name: Install zizmor
         run: pipx install zizmor==1.23.1
-      # continue-on-error: true until pre-existing findings are resolved.
-      # Once triaged, remove this flag to make zizmor a hard blocker.
+      # TODO: Remove continue-on-error once pre-existing findings are triaged.
+      # Tracked as part of the zizmor rollout project (Phase 2c).
       - name: Run zizmor
         continue-on-error: true
         run: zizmor --format plain .


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to 9 checkout steps across 3 workflows (prevents credential leakage via artifacts)
- Normalize version comment formatting
- Add `zizmor.yml` CI workflow that scans GitHub Actions on every PR targeting main:
  - Pinned to zizmor v1.23.1 via pipx
  - Pinned to ubuntu-24.04 runner, `fetch-depth: 1`
  - Passes `GH_TOKEN` for richer audits
  - Uses `continue-on-error: true` at step level — TODO tracked for removal once findings are triaged (Phase 2c)
  - `timeout-minutes: 5`
  - Includes `workflow_dispatch` for manual runs

**Checkout audit — all 9 steps verified safe for `persist-credentials: false`:**
- `maintenance-trunk-upgrade.yml` (1 checkout): trunk-check job, read-only
- `pull-request.yml` (5 checkouts): trunk-check + 4 build/test jobs, all read-only
- `release-publish.yml` (3 checkouts): setup-and-version reads VERSION file only; generate-next-snapshot and build-full-release use explicit Gradle/Maven secrets for publishing (SONATYPE_USERNAME, SONATYPE_PASSWORD, MAVEN_SIGNING_KEY) — none rely on persisted git credentials. `ncipollo/release-action` uses the GitHub API, not git push.

**Intentionally not changed:**
- `release-draft.yml` — uses `peter-evans/create-pull-request`, needs git credentials

**Permissions unchanged** — existing workflow-level permissions left as-is to avoid CI breakage (follow-up for future hardening pass).

## Test plan
- [x] Verify CI/CD pipelines run successfully
- [ ] Confirm zizmor workflow runs after merge (new workflow — only triggers once merged to main)

## Rollback plan
Revert this PR.