### PR TITLE
refactor(roktux): prepare runtime state for shoppable ads

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/LayoutVariantMarketingComponent.kt
@@ -1,7 +1,6 @@
 package com.rokt.roktux.component
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -23,6 +22,7 @@ import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
 import com.rokt.roktux.viewmodel.variants.MarketingVariantContract
 import com.rokt.roktux.viewmodel.variants.MarketingViewModel
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 
@@ -102,7 +102,7 @@ internal class LayoutVariantMarketingComponent(private val factory: LayoutUiMode
                         isPressed = isPressed,
                         offerState = offerState.copy(
                             creativeCopy = state.value.creativeCopy,
-                            customState = state.value.customState,
+                            customState = (offerState.customState + state.value.customState).toImmutableMap(),
                         ),
                         isDarkModeEnabled = isDarkModeEnabled,
                         breakpointIndex = breakpointIndex,

--- a/roktux/src/main/java/com/rokt/roktux/state/CustomStateMap.kt
+++ b/roktux/src/main/java/com/rokt/roktux/state/CustomStateMap.kt
@@ -5,8 +5,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
+// position = null means a global (layout-wide) state; non-null is scoped to that offer index.
 internal data class CustomStateKey(val position: Int?, val key: String)
 
+// Offer-position state overrides global state on lookup, missing values resolve to 0,
+// and toggle defaults from missing to 1.
 internal class CustomStateMap(
     initialGlobalStates: Map<String, Int> = emptyMap(),
     initialOfferStates: Map<Int, Map<String, Int>> = emptyMap(),
@@ -37,6 +40,7 @@ internal class CustomStateMap(
 
     operator fun get(key: CustomStateKey): Int? = state.value[key]
 
+    // Per-offer entry takes precedence; falls back to the global entry when no per-offer value exists.
     fun value(position: Int?, key: String): Int? {
         val currentState = state.value
         return if (position != null) {
@@ -62,8 +66,10 @@ internal class CustomStateMap(
 
     fun offerStates(position: Int): Map<String, Int> = statesForPosition(position = position)
 
+    // Flattened view for a given offer: per-offer keys overwrite global keys via Map `+` semantics.
     fun effectiveStates(position: Int): Map<String, Int> = globalStates() + offerStates(position)
 
+    // Public-facing shape: Int positions become String keys to match RoktViewState.offerCustomStates.
     fun allOfferStates(): Map<String, Map<String, Int>> = state.value.entries
         .mapNotNull { (key, value) ->
             key.position?.let { position ->
@@ -79,6 +85,7 @@ internal class CustomStateMap(
 
     private data class OfferState(val position: Int, val key: String, val value: Int)
 
+    // Replaces all entries for the given scope only; entries for the other scope are preserved.
     private fun replace(position: Int?, states: Map<String, Int>) {
         _state.update { currentState ->
             currentState

--- a/roktux/src/main/java/com/rokt/roktux/state/CustomStateMap.kt
+++ b/roktux/src/main/java/com/rokt/roktux/state/CustomStateMap.kt
@@ -1,0 +1,111 @@
+package com.rokt.roktux.state
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+internal data class CustomStateKey(val position: Int?, val key: String)
+
+internal class CustomStateMap(
+    initialGlobalStates: Map<String, Int> = emptyMap(),
+    initialOfferStates: Map<Int, Map<String, Int>> = emptyMap(),
+) {
+    private val _state = MutableStateFlow(
+        initialCustomStateEntries(
+            initialGlobalStates = initialGlobalStates,
+            initialOfferStates = initialOfferStates,
+        ),
+    )
+    val state: StateFlow<Map<CustomStateKey, Int>> = _state.asStateFlow()
+
+    fun update(key: CustomStateKey, value: Int) {
+        _state.update { currentState -> currentState + (key to value) }
+    }
+
+    fun update(position: Int?, key: String, value: Int) {
+        update(CustomStateKey(position, key), value)
+    }
+
+    fun replaceGlobalStates(states: Map<String, Int>) {
+        replace(position = null, states = states)
+    }
+
+    fun replaceOfferStates(position: Int, states: Map<String, Int>) {
+        replace(position = position, states = states)
+    }
+
+    operator fun get(key: CustomStateKey): Int? = state.value[key]
+
+    fun value(position: Int?, key: String): Int? {
+        val currentState = state.value
+        return if (position != null) {
+            currentState[CustomStateKey(position, key)] ?: currentState[CustomStateKey(null, key)]
+        } else {
+            currentState[CustomStateKey(null, key)]
+        }
+    }
+
+    fun valueOrDefault(position: Int?, key: String): Int = value(position, key) ?: DEFAULT_CUSTOM_STATE_VALUE
+
+    fun toggle(position: Int?, key: String): Int {
+        val nextValue = if (valueOrDefault(position, key) == ENABLED_CUSTOM_STATE_VALUE) {
+            DEFAULT_CUSTOM_STATE_VALUE
+        } else {
+            ENABLED_CUSTOM_STATE_VALUE
+        }
+        update(position, key, nextValue)
+        return nextValue
+    }
+
+    fun globalStates(): Map<String, Int> = statesForPosition(position = null)
+
+    fun offerStates(position: Int): Map<String, Int> = statesForPosition(position = position)
+
+    fun effectiveStates(position: Int): Map<String, Int> = globalStates() + offerStates(position)
+
+    fun allOfferStates(): Map<String, Map<String, Int>> = state.value.entries
+        .mapNotNull { (key, value) ->
+            key.position?.let { position ->
+                OfferState(position = position, key = key.key, value = value)
+            }
+        }
+        .groupBy { offerState -> offerState.position }
+        .toSortedMap()
+        .mapKeys { (position, _) -> position.toString() }
+        .mapValues { (_, offerStates) ->
+            offerStates.associate { offerState -> offerState.key to offerState.value }
+        }
+
+    private data class OfferState(val position: Int, val key: String, val value: Int)
+
+    private fun replace(position: Int?, states: Map<String, Int>) {
+        _state.update { currentState ->
+            currentState
+                .filterKeys { key -> key.position != position } +
+                states.mapKeys { (key, _) -> CustomStateKey(position, key) }
+        }
+    }
+
+    private fun statesForPosition(position: Int?): Map<String, Int> = state.value.entries
+        .filter { (key, _) -> key.position == position }
+        .associate { (key, value) -> key.key to value }
+
+    companion object {
+        private const val DEFAULT_CUSTOM_STATE_VALUE = 0
+        private const val ENABLED_CUSTOM_STATE_VALUE = 1
+    }
+}
+
+private fun initialCustomStateEntries(
+    initialGlobalStates: Map<String, Int>,
+    initialOfferStates: Map<Int, Map<String, Int>>,
+): Map<CustomStateKey, Int> = buildMap {
+    putAll(initialGlobalStates.toCustomStateEntries(position = null))
+    initialOfferStates.forEach { (position, states) ->
+        putAll(states.toCustomStateEntries(position = position))
+    }
+}
+
+private fun Map<String, Int>.toCustomStateEntries(position: Int?): Map<CustomStateKey, Int> =
+    mapKeys { (key, _) -> CustomStateKey(position = position, key = key) }

--- a/roktux/src/main/java/com/rokt/roktux/state/LayoutRuntimeState.kt
+++ b/roktux/src/main/java/com/rokt/roktux/state/LayoutRuntimeState.kt
@@ -2,10 +2,14 @@ package com.rokt.roktux.state
 
 import com.rokt.roktux.validation.ValidationCoordinator
 
+// Typed container for per-layout runtime state owned by LayoutViewModel/MarketingVariantViewModel,
+// replacing the previous generic `Any` bag so call sites get compile-time safety.
 internal class LayoutRuntimeState(
     val customStateMap: CustomStateMap = CustomStateMap(),
     val validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
 ) {
+    // Convenience constructor for seeding from the public RoktViewState shape,
+    // where offer positions arrive as String keys from persisted JSON.
     constructor(
         customStates: Map<String, Int>,
         offerCustomStates: Map<String, Map<String, Int>>,
@@ -43,6 +47,7 @@ internal class LayoutRuntimeState(
     fun allOfferCustomStates(): Map<String, Map<String, Int>> = customStateMap.allOfferStates()
 }
 
+// Tolerant conversion: non-numeric position keys from persisted state are dropped rather than crashing.
 private fun Map<String, Map<String, Int>>.toPositionedOfferStates(): Map<Int, Map<String, Int>> =
     mapNotNull { (position, states) ->
         position.toIntOrNull()?.let { offerPosition -> offerPosition to states }

--- a/roktux/src/main/java/com/rokt/roktux/state/LayoutRuntimeState.kt
+++ b/roktux/src/main/java/com/rokt/roktux/state/LayoutRuntimeState.kt
@@ -1,0 +1,49 @@
+package com.rokt.roktux.state
+
+import com.rokt.roktux.validation.ValidationCoordinator
+
+internal class LayoutRuntimeState(
+    val customStateMap: CustomStateMap = CustomStateMap(),
+    val validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
+) {
+    constructor(
+        customStates: Map<String, Int>,
+        offerCustomStates: Map<String, Map<String, Int>>,
+        validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
+    ) : this(
+        customStateMap = CustomStateMap(
+            initialGlobalStates = customStates,
+            initialOfferStates = offerCustomStates.toPositionedOfferStates(),
+        ),
+        validationCoordinator = validationCoordinator,
+    )
+
+    fun setGlobalCustomState(key: String, value: Int) {
+        customStateMap.update(position = null, key = key, value = value)
+    }
+
+    fun setOfferCustomState(position: Int, key: String, value: Int) {
+        customStateMap.update(position = position, key = key, value = value)
+    }
+
+    fun replaceGlobalCustomStates(states: Map<String, Int>) {
+        customStateMap.replaceGlobalStates(states)
+    }
+
+    fun replaceOfferCustomStates(position: Int, states: Map<String, Int>) {
+        customStateMap.replaceOfferStates(position, states)
+    }
+
+    fun globalCustomStates(): Map<String, Int> = customStateMap.globalStates()
+
+    fun offerCustomStates(position: Int): Map<String, Int> = customStateMap.offerStates(position)
+
+    fun effectiveCustomStates(position: Int): Map<String, Int> = customStateMap.effectiveStates(position)
+
+    fun allOfferCustomStates(): Map<String, Map<String, Int>> = customStateMap.allOfferStates()
+}
+
+private fun Map<String, Map<String, Int>>.toPositionedOfferStates(): Map<Int, Map<String, Int>> =
+    mapNotNull { (position, states) ->
+        position.toIntOrNull()?.let { offerPosition -> offerPosition to states }
+    }.toMap()

--- a/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
+++ b/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
@@ -5,7 +5,11 @@ internal enum class ValidationStatus {
     INVALID,
 }
 
+// Per-layout registry where Compose fields register validators by key, and trigger components
+// (e.g. submit buttons) call `validate(...)` before emitting events.
 internal class ValidationCoordinator {
+    // `owner` identifies the registering composable so a stale DisposableEffect cleanup from an
+    // outgoing component cannot remove a fresh registration the incoming component took for the same key.
     private data class Registration(
         val owner: Any,
         val validation: () -> ValidationStatus,
@@ -31,6 +35,8 @@ internal class ValidationCoordinator {
         }
     }
 
+    // No-op when the slot has already been taken over by another owner — protects against
+    // out-of-order Compose dispose/register sequences during recomposition.
     fun unregisterField(key: String, owner: Any) {
         synchronized(lock) {
             if (registrations[key]?.owner === owner) {
@@ -39,8 +45,14 @@ internal class ValidationCoordinator {
         }
     }
 
+    // Eagerly validates every key (no short-circuit) so all `onStatusChange` callbacks fire and
+    // every invalid field surfaces its error on a single submit attempt.
     fun validate(fields: List<String>): Boolean = fields.map { key -> validate(key) }.all { isValid -> isValid }
 
+    // Unregistered keys are treated as VALID so callers can request validation for optional fields
+    // without having to know which ones are currently mounted. The `validation()` closure and
+    // `onStatusChange` callback are invoked outside the lock to avoid reentrancy deadlocks when
+    // they trigger Compose recomposition or register/unregister calls.
     fun validate(key: String): Boolean {
         val registration = synchronized(lock) { registrations[key] } ?: return true
         val status = registration.validation()

--- a/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
+++ b/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
@@ -1,0 +1,57 @@
+package com.rokt.roktux.validation
+
+internal enum class ValidationStatus {
+    VALID,
+    INVALID,
+}
+
+internal class ValidationCoordinator {
+    private data class Registration(
+        val owner: Any,
+        val validation: () -> ValidationStatus,
+        val onStatusChange: (ValidationStatus) -> Unit,
+        val lastStatus: ValidationStatus? = null,
+    )
+
+    private val lock = Any()
+    private val registrations = mutableMapOf<String, Registration>()
+
+    fun registerField(
+        key: String,
+        owner: Any,
+        validation: () -> ValidationStatus,
+        onStatusChange: (ValidationStatus) -> Unit,
+    ) {
+        synchronized(lock) {
+            registrations[key] = Registration(
+                owner = owner,
+                validation = validation,
+                onStatusChange = onStatusChange,
+            )
+        }
+    }
+
+    fun unregisterField(key: String, owner: Any) {
+        synchronized(lock) {
+            if (registrations[key]?.owner === owner) {
+                registrations.remove(key)
+            }
+        }
+    }
+
+    fun validate(fields: List<String>): Boolean = fields.map { key -> validate(key) }.all { isValid -> isValid }
+
+    fun validate(key: String): Boolean {
+        val registration = synchronized(lock) { registrations[key] } ?: return true
+        val status = registration.validation()
+
+        synchronized(lock) {
+            if (registrations[key]?.owner === registration.owner) {
+                registrations[key] = registration.copy(lastStatus = status)
+            }
+        }
+
+        registration.onStatusChange(status)
+        return status == ValidationStatus.VALID
+    }
+}

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -30,6 +30,7 @@ import com.rokt.roktux.event.RoktUxEvent
 import com.rokt.roktux.event.UrlEventState
 import com.rokt.roktux.event.toEventType
 import com.rokt.roktux.logging.RoktUXLogger
+import com.rokt.roktux.state.LayoutRuntimeState
 import com.rokt.roktux.utils.chunk
 import com.rokt.roktux.utils.isEmbedded
 import com.rokt.roktux.viewmodel.base.BaseViewModel
@@ -57,8 +58,8 @@ internal class LayoutViewModel(
     private val mainDispatcher: CoroutineDispatcher,
     private val handleUrlByApp: Boolean,
     private var currentOffer: Int,
-    private var customStates: Map<String, Int>,
-    private var offerCustomStates: Map<String, Map<String, Int>>,
+    customStates: Map<String, Int>,
+    offerCustomStates: Map<String, Map<String, Int>>,
     private var edgeToEdgeDisplay: Boolean,
 ) : BaseViewModel<LayoutContract.LayoutEvent, LayoutUiState, LayoutContract.LayoutEffect>() {
 
@@ -67,6 +68,10 @@ internal class LayoutViewModel(
     private lateinit var pluginModel: PluginModel
     private lateinit var pluginViewState: RoktViewState
     private var viewableItems: AtomicReference<Int> = AtomicReference(DEFAULT_VIEWABLE_ITEMS)
+    private val runtimeState = LayoutRuntimeState(
+        customStates = customStates,
+        offerCustomStates = offerCustomStates,
+    )
 
     // SDK's internal thread-safe structure to track URL states
     private val urlEventStateMap = ConcurrentHashMap<String, UrlEventState>()
@@ -166,8 +171,8 @@ internal class LayoutViewModel(
                         targetOfferIndex = currentOffer,
                         creativeCopy = persistentMapOf(),
                         breakpoints = pluginModel.breakpoint,
-                        customState = customStates.toImmutableMap(),
-                        offerCustomStates = offerCustomStates.mapValues { it.value.toImmutableMap() }.toImmutableMap(),
+                        customState = runtimeState.globalCustomStates().toImmutableMap(),
+                        offerCustomStates = runtimeState.immutableOfferCustomStates(),
                     ),
                 ),
             )
@@ -271,7 +276,14 @@ internal class LayoutViewModel(
             }
 
             is LayoutContract.LayoutEvent.SetOfferCustomState -> {
-                offerCustomStates += (event.offerId.toString() to event.customState)
+                runtimeState.replaceOfferCustomStates(event.offerId, event.customState)
+                updateState { currentUiState ->
+                    currentUiState.copy(
+                        offerUiState = currentUiState.offerUiState.copy(
+                            offerCustomStates = runtimeState.immutableOfferCustomStates(),
+                        ),
+                    )
+                }
                 sendViewState()
             }
 
@@ -492,10 +504,12 @@ internal class LayoutViewModel(
     }
 
     private fun updateCustomState(key: String, value: Int) {
-        customStates += (key to value)
+        runtimeState.setGlobalCustomState(key, value)
         updateState { currentUiState ->
             currentUiState.copy(
-                offerUiState = currentUiState.offerUiState.copy(customState = customStates.toImmutableMap()),
+                offerUiState = currentUiState.offerUiState.copy(
+                    customState = runtimeState.globalCustomStates().toImmutableMap(),
+                ),
             )
         }
     }
@@ -635,13 +649,16 @@ internal class LayoutViewModel(
     private fun sendViewState(currentOffer: Int = this.currentOffer, isDismissed: Boolean = false) {
         pluginViewState = RoktViewState(
             pluginId = pluginId,
-            customStates = customStates.toImmutableMap(),
-            offerCustomStates = offerCustomStates.toImmutableMap(),
+            customStates = runtimeState.globalCustomStates().toImmutableMap(),
+            offerCustomStates = runtimeState.allOfferCustomStates().toImmutableMap(),
             offerIndex = currentOffer,
             pluginDismissed = isDismissed,
         )
         viewStateChange(pluginViewState)
     }
+
+    private fun LayoutRuntimeState.immutableOfferCustomStates() =
+        allOfferCustomStates().mapValues { (_, value) -> value.toImmutableMap() }.toImmutableMap()
 
     companion object {
         private const val KEY_INITIATOR = "initiator"

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/variants/MarketingVariantViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/variants/MarketingVariantViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.rokt.modelmapper.mappers.ModelMapper
+import com.rokt.roktux.state.CustomStateMap
+import com.rokt.roktux.state.LayoutRuntimeState
 import com.rokt.roktux.viewmodel.base.BaseViewModel
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import kotlinx.collections.immutable.toImmutableMap
@@ -19,10 +21,15 @@ internal class MarketingViewModel(
     val currentOffer: Int,
     modelMapper: ModelMapper,
     private val ioDispatcher: CoroutineDispatcher,
-    private var customState: Map<String, Int>,
+    customState: Map<String, Int>,
 ) : BaseViewModel<LayoutContract.LayoutEvent, MarketingVariantUiState, MarketingVariantContract.LayoutVariantEffect>() {
     private var offerViewedJob: Job? = null
     private var signalViewedSent = AtomicBoolean(false)
+    private val runtimeState = LayoutRuntimeState(
+        customStateMap = CustomStateMap(
+            initialOfferStates = mapOf(currentOffer to customState),
+        ),
+    )
 
     init {
         val slot = modelMapper.getSavedExperience()?.plugins?.getOrNull(
@@ -31,7 +38,13 @@ internal class MarketingViewModel(
         val layoutVariantSchema = slot?.layoutVariant?.layoutVariantSchema
         val creativeCopy = slot?.offer?.creative?.copy
         if (layoutVariantSchema != null && creativeCopy != null) {
-            setSuccessState(MarketingVariantUiState(layoutVariantSchema, creativeCopy, customState.toImmutableMap()))
+            setSuccessState(
+                MarketingVariantUiState(
+                    layoutVariantSchema,
+                    creativeCopy,
+                    runtimeState.offerCustomStates(currentOffer).toImmutableMap(),
+                ),
+            )
         }
     }
 
@@ -47,7 +60,7 @@ internal class MarketingViewModel(
                     MarketingVariantContract.LayoutVariantEffect.PropagateEvent(
                         LayoutContract.LayoutEvent.SetOfferCustomState(
                             currentOffer,
-                            customState,
+                            runtimeState.offerCustomStates(currentOffer),
                         ),
                     )
                 }
@@ -84,10 +97,10 @@ internal class MarketingViewModel(
     }
 
     private fun updateCustomState(key: String, value: Int) {
-        customState += (key to value)
+        runtimeState.setOfferCustomState(currentOffer, key, value)
         updateState { currentUiState ->
             currentUiState.copy(
-                customState = customState.toImmutableMap(),
+                customState = runtimeState.offerCustomStates(currentOffer).toImmutableMap(),
             )
         }
     }

--- a/roktux/src/test/java/com/rokt/roktux/state/CustomStateMapTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/state/CustomStateMapTest.kt
@@ -1,0 +1,73 @@
+package com.rokt.roktux.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CustomStateMapTest {
+
+    @Test
+    fun `initialises global and offer states with typed keys`() {
+        val customStateMap = CustomStateMap(
+            initialGlobalStates = mapOf("ReadMoreState" to 1),
+            initialOfferStates = mapOf(2 to mapOf("DataImageCarousel.hero" to 3)),
+        )
+
+        assertThat(customStateMap[CustomStateKey(position = null, key = "ReadMoreState")]).isEqualTo(1)
+        assertThat(customStateMap[CustomStateKey(position = 2, key = "DataImageCarousel.hero")]).isEqualTo(3)
+        assertThat(customStateMap.globalStates()).containsEntry("ReadMoreState", 1)
+        assertThat(customStateMap.offerStates(2)).containsEntry("DataImageCarousel.hero", 3)
+    }
+
+    @Test
+    fun `offer state overrides global state when resolving effective values`() {
+        val customStateMap = CustomStateMap(
+            initialGlobalStates = mapOf("shared" to 1, "globalOnly" to 4),
+            initialOfferStates = mapOf(1 to mapOf("shared" to 2, "localOnly" to 3)),
+        )
+
+        assertThat(customStateMap.valueOrDefault(position = 1, key = "shared")).isEqualTo(2)
+        assertThat(customStateMap.valueOrDefault(position = 2, key = "shared")).isEqualTo(1)
+        assertThat(customStateMap.effectiveStates(1)).containsEntry("shared", 2)
+        assertThat(customStateMap.effectiveStates(1)).containsEntry("globalOnly", 4)
+        assertThat(customStateMap.effectiveStates(1)).containsEntry("localOnly", 3)
+    }
+
+    @Test
+    fun `missing state resolves to zero`() {
+        val customStateMap = CustomStateMap()
+
+        assertThat(customStateMap.value(position = 0, key = "missing")).isNull()
+        assertThat(customStateMap.valueOrDefault(position = 0, key = "missing")).isEqualTo(0)
+    }
+
+    @Test
+    fun `toggle defaults missing state to enabled and flips existing enabled value`() {
+        val customStateMap = CustomStateMap()
+
+        assertThat(customStateMap.toggle(position = 0, key = "ToggleButtonState")).isEqualTo(1)
+        assertThat(customStateMap[CustomStateKey(position = 0, key = "ToggleButtonState")]).isEqualTo(1)
+
+        assertThat(customStateMap.toggle(position = 0, key = "ToggleButtonState")).isEqualTo(0)
+        assertThat(customStateMap[CustomStateKey(position = 0, key = "ToggleButtonState")]).isEqualTo(0)
+    }
+
+    @Test
+    fun `replaceOfferStates preserves global and other offer states`() {
+        val customStateMap = CustomStateMap(
+            initialGlobalStates = mapOf("global" to 1),
+            initialOfferStates = mapOf(
+                0 to mapOf("first" to 1),
+                1 to mapOf("second" to 2),
+            ),
+        )
+
+        customStateMap.replaceOfferStates(position = 0, states = mapOf("replacement" to 9))
+
+        assertThat(customStateMap.globalStates()).containsEntry("global", 1)
+        assertThat(customStateMap.offerStates(0)).containsOnlyKeys("replacement")
+        assertThat(customStateMap.offerStates(0)).containsEntry("replacement", 9)
+        assertThat(customStateMap.offerStates(1)).containsEntry("second", 2)
+        assertThat(customStateMap.allOfferStates()).containsEntry("0", mapOf("replacement" to 9))
+        assertThat(customStateMap.allOfferStates()).containsEntry("1", mapOf("second" to 2))
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/state/LayoutRuntimeStateTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/state/LayoutRuntimeStateTest.kt
@@ -1,0 +1,22 @@
+package com.rokt.roktux.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class LayoutRuntimeStateTest {
+
+    @Test
+    fun `initialises custom state from public view state maps`() {
+        val runtimeState = LayoutRuntimeState(
+            customStates = mapOf("ReadMoreState" to 1),
+            offerCustomStates = mapOf(
+                "2" to mapOf("DataImageCarousel.hero" to 3),
+                "not-an-offer-position" to mapOf("ignored" to 4),
+            ),
+        )
+
+        assertThat(runtimeState.globalCustomStates()).containsEntry("ReadMoreState", 1)
+        assertThat(runtimeState.offerCustomStates(2)).containsEntry("DataImageCarousel.hero", 3)
+        assertThat(runtimeState.allOfferCustomStates()).containsOnlyKeys("2")
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/validation/ValidationCoordinatorTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/validation/ValidationCoordinatorTest.kt
@@ -1,0 +1,87 @@
+package com.rokt.roktux.validation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ValidationCoordinatorTest {
+
+    @Test
+    fun `missing field is valid`() {
+        val coordinator = ValidationCoordinator()
+
+        assertThat(coordinator.validate("missing")).isTrue()
+    }
+
+    @Test
+    fun `validate runs every requested field before returning aggregate result`() {
+        val coordinator = ValidationCoordinator()
+        val owner = Any()
+        val statuses = mutableListOf<String>()
+
+        coordinator.registerField(
+            key = "first",
+            owner = owner,
+            validation = { ValidationStatus.INVALID },
+            onStatusChange = { statuses += "first:$it" },
+        )
+        coordinator.registerField(
+            key = "second",
+            owner = owner,
+            validation = { ValidationStatus.VALID },
+            onStatusChange = { statuses += "second:$it" },
+        )
+
+        assertThat(coordinator.validate(listOf("first", "second"))).isFalse()
+        assertThat(statuses).containsExactly("first:INVALID", "second:VALID")
+    }
+
+    @Test
+    fun `unregister only removes field for matching owner`() {
+        val coordinator = ValidationCoordinator()
+        val owner = Any()
+        val otherOwner = Any()
+        var validationCount = 0
+
+        coordinator.registerField(
+            key = "field",
+            owner = owner,
+            validation = {
+                validationCount += 1
+                ValidationStatus.INVALID
+            },
+            onStatusChange = {},
+        )
+
+        coordinator.unregisterField(key = "field", owner = otherOwner)
+        assertThat(coordinator.validate("field")).isFalse()
+        assertThat(validationCount).isEqualTo(1)
+
+        coordinator.unregisterField(key = "field", owner = owner)
+        assertThat(coordinator.validate("field")).isTrue()
+        assertThat(validationCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `registering the same key replaces previous owner`() {
+        val coordinator = ValidationCoordinator()
+        val firstOwner = Any()
+        val secondOwner = Any()
+
+        coordinator.registerField(
+            key = "field",
+            owner = firstOwner,
+            validation = { ValidationStatus.INVALID },
+            onStatusChange = {},
+        )
+        coordinator.registerField(
+            key = "field",
+            owner = secondOwner,
+            validation = { ValidationStatus.VALID },
+            onStatusChange = {},
+        )
+
+        coordinator.unregisterField(key = "field", owner = firstOwner)
+
+        assertThat(coordinator.validate("field")).isTrue()
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -348,6 +348,26 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `SetCustomState Event should update custom state and propagate the event`() = runTest {
+        // Arrange
+        val key = "key"
+        val value = 1
+
+        // Act
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.SetCustomState(key, value))
+
+        // Assert
+        verify {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.customStates).containsEntry(key, value)
+                    assertThat(state.offerCustomStates).isEmpty()
+                },
+            )
+        }
+    }
+
+    @Test
     fun `FirstOfferLoaded should send the RoktPlatformEvent with SignalImpression for the layout and required metadata`() {
         // Act
         layoutViewModel.setEvent(LayoutContract.LayoutEvent.FirstOfferLoaded)

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/variants/MarketingViewModelTest.kt
@@ -79,6 +79,38 @@ class MarketingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `SetCustomState event should preserve existing custom state when propagating the event`() = runTest {
+        // Given
+        viewModel = MarketingViewModel(
+            0,
+            modelMapper,
+            ioDispatcher,
+            mapOf("existingKey" to 2),
+        )
+        val key = "key"
+        val value = 1
+
+        // When
+        viewModel.setEvent(LayoutContract.LayoutEvent.SetCustomState(key, value))
+        val viewState = viewModel.viewState.value
+        val effect = viewModel.effect.first()
+
+        // Then
+        val successState = viewState as BaseContract.BaseViewState.Success
+        assertThat(successState.value.customState)
+            .containsEntry("existingKey", 2)
+            .containsEntry(key, value)
+        assertThat(effect).isInstanceOf(MarketingVariantContract.LayoutVariantEffect.PropagateEvent::class.java)
+        val propagateEvent = effect as MarketingVariantContract.LayoutVariantEffect.PropagateEvent
+        assertThat(propagateEvent.event).isEqualTo(
+            LayoutContract.LayoutEvent.SetOfferCustomState(
+                0,
+                mapOf("existingKey" to 2, key to value),
+            ),
+        )
+    }
+
+    @Test
     fun `UserInteracted should set the SetSignalViewed effect only once`() = runTest {
         // Given
         val event = LayoutContract.LayoutEvent.UserInteracted


### PR DESCRIPTION
Add typed layout runtime state for custom states and validation so later shoppable ads work can build on explicit internal state.

Preserve the existing public view-state maps at the SDK boundary while resolving offer-local custom state over global state internally.

<!-- markdownlint-disable MD041 -->

## Background

- Prepare the UX helper runtime state for staged shoppable ads work .
- This PR targets `workstation-shoppable-ads` so later shoppable ads PRs can build on the shared workstation branch before the final merge to `main`.

## What Has Changed

- Added typed internal layout runtime state for custom states and validation.
- Added `CustomStateMap` using `(position: Int?, key: String)` keys.
- Preserved the existing public `customStates` and `offerCustomStates` view-state shape.
- Updated layout and marketing view models to write custom state through the runtime state.
- Applied offer-local custom state over global state for marketing variant rendering.
- Added an internal `ValidationCoordinator` with owner-aware unregister and eager multi-field validation.
- Added unit coverage for custom-state initialization, precedence, toggle defaults, validation behavior, and view-state export.

## Screenshots/Video

- Not applicable; this is an internal runtime-state refactor.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes



## Reference Issue (For employees only. Ignore if you are an outside contributor)


