### PR TITLE
feat: expose UXHelper layout schema version

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/RoktUx.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktUx.kt
@@ -24,6 +24,14 @@ public object RoktUx {
     }
 
     /**
+     * Get the DCUI layout schema version supported by RoktUXHelper.
+     *
+     * @return The full layout schema version.
+     */
+    @JvmStatic
+    public fun getLayoutSchemaVersion(): String = BuildConfig.SCHEMA_VERSION
+
+    /**
      * Get the Rokt Integration configuration. Data to be included in the Rokt API request.
      *
      * @param context The Android Context.
@@ -34,7 +42,7 @@ public object RoktUx {
         version = BuildConfig.SDK_VERSION,
         packageName = context.packageName,
         packageVersion = context.getPackageVersion(),
-        layoutSchemaVersion = BuildConfig.SCHEMA_VERSION,
+        layoutSchemaVersion = getLayoutSchemaVersion(),
         framework = SDK_FRAMEWORK,
         platform = SDK_PLATFORM,
         operatingSystem = SDK_OPERATING_SYSTEM,

--- a/roktux/src/test/java/com/rokt/RoktUxTest.kt
+++ b/roktux/src/test/java/com/rokt/RoktUxTest.kt
@@ -35,6 +35,7 @@ class RoktUxTest {
         }
         with(sdkConfig.layoutSchemaVersion) {
             assertEquals(BuildConfig.SCHEMA_VERSION, this)
+            assertEquals(RoktUx.getLayoutSchemaVersion(), this)
             assertTrue(isValidSemver(this))
         }
         assertEquals("com.rokt.roktux.test", sdkConfig.packageName)
@@ -46,6 +47,11 @@ class RoktUxTest {
         assertEquals("Phone", sdkConfig.deviceType)
         assertEquals("en_US", sdkConfig.deviceLocale)
         assertTrue(isValidJson(sdkConfig.toJsonString()))
+    }
+
+    @Test
+    fun `getLayoutSchemaVersion should return schema version`() {
+        assertEquals(BuildConfig.SCHEMA_VERSION, RoktUx.getLayoutSchemaVersion())
     }
 
     private fun isValidJson(data: String): Boolean = try {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Android SDK needs to send the layout schema version supported by the UXHelper renderer in the `rokt-layout-schema-version` request header. Exposing the UXHelper schema version directly lets SDK callers align request metadata with the renderer instead of duplicating or deriving that value elsewhere.

## What Has Changed

- Added public `RoktUx.getLayoutSchemaVersion()` API that returns the full UXHelper schema version.
- Updated `getIntegrationConfig(context).layoutSchemaVersion` to source the value from the new API.
- Added unit test coverage verifying the public API matches `BuildConfig.SCHEMA_VERSION` and integration config.

## Screenshots/Video

- N/A — no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- `VERSION` is intentionally unchanged because it is updated automatically by the release process.