### PR TITLE
fix(catalog): validate required dropdown selections

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
@@ -12,9 +12,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
@@ -42,6 +45,9 @@ import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.modelmapper.uimodel.ModifierProperties
 import com.rokt.modelmapper.uimodel.StateBlock
 import com.rokt.modelmapper.utils.ROKT_ICONS_FONT_FAMILY
+import com.rokt.roktux.di.layout.LocalLayoutComponent
+import com.rokt.roktux.validation.ValidationCoordinator
+import com.rokt.roktux.validation.ValidationStatus
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
 import kotlin.math.roundToInt
@@ -65,6 +71,11 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
 
         val selectedIndex = offerState.customState[model.customStateKey]
             ?.takeIf { it in options.indices }
+        val validationFieldKey = model.validationFieldKey?.takeIf { it.isNotBlank() }
+        val validationCoordinator = LocalLayoutComponent.current[ValidationCoordinator::class.java]
+        val selectedIndexState = rememberUpdatedState(selectedIndex)
+        var pendingSelectedIndex by remember(model.customStateKey) { mutableStateOf<Int?>(null) }
+        var validationStatus by remember(validationFieldKey) { mutableStateOf(ValidationStatus.VALID) }
         var isExpanded by remember { mutableStateOf(false) }
         var headSize by remember { mutableStateOf(IntSize.Zero) }
         var boxBounds by remember { mutableStateOf<IntRect?>(null) }
@@ -79,10 +90,26 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
         val density = LocalDensity.current
         val layoutDirection = LocalLayoutDirection.current
         val view = LocalView.current
+        val showValidationError = validationStatus == ValidationStatus.INVALID
         val rootContainer = modifierFactory.createContainerUiProperties(
             containerProperties = model.containerProperties,
             index = breakpointIndex,
             isPressed = isPressed,
+        )
+        LaunchedEffect(selectedIndex) {
+            pendingSelectedIndex = null
+        }
+        RegisterValidator(
+            validationCoordinator = validationCoordinator,
+            validationFieldKey = validationFieldKey,
+            validation = {
+                if ((pendingSelectedIndex ?: selectedIndexState.value) == null) {
+                    ValidationStatus.INVALID
+                } else {
+                    ValidationStatus.VALID
+                }
+            },
+            onStatusChange = { status -> validationStatus = status },
         )
 
         Column(
@@ -109,6 +136,7 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                     displayText = displayText(model, selectedIndex, offerState),
                     isExpanded = isExpanded,
                     isSelected = selectedIndex != null,
+                    showValidationError = showValidationError,
                     isDarkModeEnabled = isDarkModeEnabled,
                     breakpointIndex = breakpointIndex,
                     offerState = offerState,
@@ -164,6 +192,7 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                                 onSelected = { optionIndex ->
                                     val updatedSelections =
                                         selectedIndices(model, offerState) + (model.attributeIndex to optionIndex)
+                                    pendingSelectedIndex = optionIndex
                                     onEventSent(
                                         LayoutContract.LayoutEvent.SetCustomState(
                                             model.customStateKey,
@@ -174,11 +203,50 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                                         onEventSent(LayoutContract.LayoutEvent.SetActiveCatalogItem(activeItemIndex))
                                     }
                                     isExpanded = false
+                                    if (validationFieldKey != null &&
+                                        (model.validateOnChange || validationStatus == ValidationStatus.INVALID)
+                                    ) {
+                                        validationCoordinator.validate(validationFieldKey)
+                                    }
                                 },
                             )
                         }
                     }
                 }
+            }
+            ValidationError(
+                model = model,
+                isVisible = showValidationError,
+                isDarkModeEnabled = isDarkModeEnabled,
+                breakpointIndex = breakpointIndex,
+                offerState = offerState,
+                onEventSent = onEventSent,
+            )
+        }
+    }
+
+    @Composable
+    private fun RegisterValidator(
+        validationCoordinator: ValidationCoordinator,
+        validationFieldKey: String?,
+        validation: () -> ValidationStatus,
+        onStatusChange: (ValidationStatus) -> Unit,
+    ) {
+        val owner = remember(validationFieldKey) { Any() }
+        DisposableEffect(validationCoordinator, validationFieldKey, owner) {
+            if (validationFieldKey != null) {
+                validationCoordinator.registerField(
+                    key = validationFieldKey,
+                    owner = owner,
+                    validation = validation,
+                    onStatusChange = onStatusChange,
+                )
+            }
+            onDispose {
+                if (validationFieldKey != null) {
+                    validationCoordinator.unregisterField(key = validationFieldKey, owner = owner)
+                }
+                onStatusChange(ValidationStatus.VALID)
             }
         }
     }
@@ -189,6 +257,7 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
         displayText: String,
         isExpanded: Boolean,
         isSelected: Boolean,
+        showValidationError: Boolean,
         isDarkModeEnabled: Boolean,
         breakpointIndex: Int,
         offerState: OfferUiState,
@@ -199,7 +268,11 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
     ) {
         val interactionSource = remember { MutableInteractionSource() }
         val isPressed by interactionSource.collectIsPressedAsState()
-        val resolvedStyle = model.head.resolve(isSelected = isSelected, isDisabled = false, isErrored = false)
+        val resolvedStyle = model.head.resolve(
+            isSelected = isSelected,
+            isDisabled = false,
+            isErrored = showValidationError,
+        )
         val style = resolvedStyle.style
         val resolvedIconStyle = model.icon.resolve(isSelected = isSelected, isDisabled = false, isErrored = false)
         val iconStyle = resolvedIconStyle.style
@@ -270,6 +343,46 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                 style = iconTextStyle.textStyle,
             )
         }
+    }
+
+    @Composable
+    private fun ValidationError(
+        model: LayoutSchemaUiModel.CatalogDropdownUiModel,
+        isVisible: Boolean,
+        isDarkModeEnabled: Boolean,
+        breakpointIndex: Int,
+        offerState: OfferUiState,
+        onEventSent: (LayoutContract.LayoutEvent) -> Unit,
+    ) {
+        val message = model.validationErrorMessage
+        if (!isVisible || message.isNullOrEmpty()) return
+
+        val resolvedStyle = model.error.resolve(isSelected = false, isDisabled = false, isErrored = false)
+        val style = resolvedStyle.style
+        val textStyle = modifierFactory.createTextStyle(
+            text = message,
+            textStyles = style?.textStyles,
+            breakpointIndex = breakpointIndex,
+            isPressed = false,
+            isDarkModeEnabled = isDarkModeEnabled,
+            baseStyles = resolvedStyle.baseStyle?.textStyles,
+            offerState = offerState,
+            onEventSent = onEventSent,
+        )
+
+        Text(
+            modifier = modifierFactory.createModifier(
+                modifierPropertiesList = style?.ownModifiers,
+                conditionalTransitionModifier = null,
+                breakpointIndex = breakpointIndex,
+                isPressed = false,
+                isDarkModeEnabled = isDarkModeEnabled,
+                offerState = offerState,
+                basePropertiesList = resolvedStyle.baseStyle?.ownModifiers,
+            ),
+            text = textStyle.value,
+            style = textStyle.textStyle,
+        )
     }
 
     @Composable

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
@@ -10,6 +10,7 @@ import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.component.LayoutUiModelFactory
 import com.rokt.roktux.event.RoktPlatformEvent
 import com.rokt.roktux.event.RoktUxEvent
+import com.rokt.roktux.validation.ValidationCoordinator
 import com.rokt.roktux.viewmodel.layout.LayoutViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -36,6 +37,7 @@ internal class LayoutModule(
 
         this.provideModuleScoped { DataBindingImpl() }
         this.provideModuleScoped { LayoutUiModelFactory() }
+        this.provideModuleScoped { ValidationCoordinator() }
         this.provideModuleScoped { ExperienceModelMapperImpl(get(EXPERIENCE), get()) }
         this.provideModuleScoped(EXPERIENCE) { experience }
         this.provideModuleScoped(LOCATION) { location }
@@ -56,6 +58,7 @@ internal class LayoutModule(
                 customStates = customStates,
                 offerCustomStates = offerCustomStates,
                 domainStates = domainStates,
+                validationCoordinator = get(),
                 edgeToEdgeDisplay = edgeToEdgeDisplay,
             )
         }

--- a/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
+++ b/roktux/src/main/java/com/rokt/roktux/validation/ValidationCoordinator.kt
@@ -45,6 +45,8 @@ internal class ValidationCoordinator {
         }
     }
 
+    fun isRegistered(key: String): Boolean = synchronized(lock) { registrations.containsKey(key) }
+
     // Eagerly validates every key (no short-circuit) so all `onStatusChange` callbacks fire and
     // every invalid field surfaces its error on a single submit attempt.
     fun validate(fields: List<String>): Boolean = fields.map { key -> validate(key) }.all { isValid -> isValid }

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -827,6 +827,7 @@ internal class LayoutViewModel(
         private val customStates: Map<String, Int>,
         private val offerCustomStates: Map<String, Map<String, Int>>,
         private val domainStates: Map<String, Int>,
+        private val validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
         private val edgeToEdgeDisplay: Boolean,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -846,6 +847,7 @@ internal class LayoutViewModel(
                     customStates = customStates,
                     offerCustomStates = offerCustomStates,
                     domainStates = domainStates,
+                    validationCoordinator = validationCoordinator,
                     edgeToEdgeDisplay = edgeToEdgeDisplay,
                 ) as T
             }

--- a/roktux/src/test/assets/CatalogDropdownComponent/CatalogDropdown_with_Group.json
+++ b/roktux/src/test/assets/CatalogDropdownComponent/CatalogDropdown_with_Group.json
@@ -4,6 +4,18 @@
     "a11yLabel": "Select shoe size",
     "placeholderValue": "Select size",
     "unavailableValue": "Unavailable",
+    "validatorFieldConfig": {
+      "validationFieldKey": "dropDownSelection",
+      "validators": [
+        {
+          "type": "Required",
+          "value": {
+            "message": "Select a size before paying"
+          }
+        }
+      ],
+      "validateOnChange": true
+    },
     "styles": {
       "elements": {
         "own": [
@@ -72,6 +84,17 @@
                   "light": "#eef7ff",
                   "dark": "#102030"
                 }
+              }
+            },
+            "errored": {
+              "border": {
+                "borderColor": {
+                  "light": "#b91c1c",
+                  "dark": "#fca5a5"
+                },
+                "borderStyle": "solid",
+                "borderWidth": "1",
+                "borderRadius": 6
               }
             }
           }

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
@@ -23,7 +23,9 @@ import com.rokt.core.testutils.annotations.DcuiConfig
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.core.testutils.annotations.DcuiOfferJson
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
+import com.rokt.roktux.validation.ValidationCoordinator
 import com.rokt.roktux.viewmodel.layout.LayoutContract
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -163,5 +165,32 @@ class CatalogDropdownComponentTest : BaseDcuiEspressoTest() {
         composeTestRule.onNodeWithText("32oz")
             .assertIsDisplayed()
             .assertIsNotEnabled()
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "CatalogDropdownComponent/CatalogDropdown_with_Group.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_catalog_item_group.json")
+    fun testCatalogDropdownRequiredValidationShowsAndClearsError() {
+        val validationCoordinator = dcuiComponentRule.layoutComponent[ValidationCoordinator::class.java]
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            validationCoordinator.isRegistered("dropDownSelection")
+        }
+        composeTestRule.runOnIdle {
+            assertThat(validationCoordinator.validate("dropDownSelection")).isFalse()
+        }
+        composeTestRule.onNodeWithText("Select a size before paying").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Select size").performClick()
+        composeTestRule.onNodeWithText("16oz")
+            .assertIsDisplayed()
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Select a size before paying").assertDoesNotExist()
+        composeTestRule.runOnIdle {
+            assertThat(validationCoordinator.validate("dropDownSelection")).isTrue()
+        }
     }
 }

--- a/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
@@ -2,11 +2,11 @@ package com.rokt.roktux.testutil
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.test.platform.app.InstrumentationRegistry
 import com.rokt.core.testutils.BaseComponentRule
 import com.rokt.core.testutils.annotations.DcuiBreakpoint
 import com.rokt.core.testutils.annotations.DcuiNodeComponentState
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 class DcuiComponentRule(val composeTestRule: ComposeContentTestRule) : BaseComponentRule(composeTestRule, true) {
 
     lateinit var uiModel: LayoutSchemaUiModel
+    internal lateinit var layoutComponent: LayoutComponent
 
     internal val capturedEvents = mutableListOf<BaseContract.BaseEvent>()
 
@@ -58,25 +59,26 @@ class DcuiComponentRule(val composeTestRule: ComposeContentTestRule) : BaseCompo
     ) {
         val factory = LayoutUiModelFactory()
         val breakpoints = buildBreakpoints(dcuiNodeComponentState?.breakpoints)
+        layoutComponent = LayoutComponent(
+            experienceResponse = "",
+            location = "",
+            startTimeStamp = System.currentTimeMillis(),
+            onUxEvent = {},
+            onPlatformEvent = {},
+            onViewStateChange = {},
+            imageLoader = NetworkStrategy().getImageLoader(InstrumentationRegistry.getInstrumentation().targetContext),
+            handleUrlByApp = true,
+            currentOffer = 0,
+            customStates = mapOf(),
+            offerCustomStates = mapOf(),
+            domainStates = mapOf(),
+            edgeToEdgeDisplay = false,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO,
+        )
         composeTestRule.setContent {
             CompositionLocalProvider(
-                LocalLayoutComponent provides LayoutComponent(
-                    experienceResponse = "",
-                    location = "",
-                    startTimeStamp = System.currentTimeMillis(),
-                    onUxEvent = {},
-                    onPlatformEvent = {},
-                    onViewStateChange = {},
-                    imageLoader = NetworkStrategy().getImageLoader(LocalContext.current),
-                    handleUrlByApp = true,
-                    currentOffer = 0,
-                    customStates = mapOf(),
-                    offerCustomStates = mapOf(),
-                    domainStates = mapOf(),
-                    edgeToEdgeDisplay = false,
-                    mainDispatcher = Dispatchers.Main,
-                    ioDispatcher = Dispatchers.IO,
-                ),
+                LocalLayoutComponent provides layoutComponent,
                 LocalFontFamilyProvider provides persistentMapOf(
                     "roboto" to FontFamily.Default,
                     ROKT_ICONS_FONT_FAMILY to FontFamily(Font(resId = R.font.rokt_icons)),

--- a/roktux/src/test/java/com/rokt/roktux/validation/ValidationCoordinatorTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/validation/ValidationCoordinatorTest.kt
@@ -13,6 +13,25 @@ class ValidationCoordinatorTest {
     }
 
     @Test
+    fun `is registered reflects field lifecycle`() {
+        val coordinator = ValidationCoordinator()
+        val owner = Any()
+
+        coordinator.registerField(
+            key = "field",
+            owner = owner,
+            validation = { ValidationStatus.VALID },
+            onStatusChange = {},
+        )
+
+        assertThat(coordinator.isRegistered("field")).isTrue()
+
+        coordinator.unregisterField(key = "field", owner = owner)
+
+        assertThat(coordinator.isRegistered("field")).isFalse()
+    }
+
+    @Test
     fun `validate runs every requested field before returning aggregate result`() {
         val coordinator = ValidationCoordinator()
         val owner = Any()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Required catalog dropdowns are part of the shoppable Ads purchase flow, but Android only mapped the validation configuration without registering dropdown fields at runtime. As a result, Device Pay validation triggers could treat an unselected required variant dropdown as valid.

## What Has Changed

- Registered `CatalogDropdown` fields with the shared layout `ValidationCoordinator` when a validation field key is configured.
- Rendered the configured dropdown validation error message and errored head style after validation fails.
- Revalidated dropdowns after selection changes so the error clears once a shopper selects an option.
- Shared the same validation coordinator between the layout DI component, Compose dropdowns, and `LayoutViewModel` purchase validation.
- Added focused tests for required dropdown validation registration, error rendering, clearing after selection, and validation coordinator registration state.

## Screenshots/Video

- This changes dropdown validation UI. Please attach a screenshot or short video showing the required dropdown error state before merging.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Local checks passed:
  - `./gradlew test --no-daemon --max-workers=2 -Dkotlin.daemon.jvm.options="-Xmx1g"`
  - `./gradlew lint --no-daemon --max-workers=2`
  - `./gradlew --no-daemon --max-workers=2 assembleDebug -Dkotlin.daemon.jvm.options="-Xmx1g"`
  - `trunk check --ci`
  - `./gradlew verifyRoborazziRelease -PenableSnapshotTests --tests "com.rokt.roktux.snapshot.*" --no-daemon --max-workers=2 -Dkotlin.daemon.jvm.options="-Xmx1g"` after copying tracked snapshots into `roktux/build/outputs/roborazzi`, matching the workflow setup step.