### PR TITLE
feat(catalog): add forward payment for response buttons

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/mappers/ComplexModelMapper.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/mappers/ComplexModelMapper.kt
@@ -241,6 +241,7 @@ internal fun transformCatalogResponseButton(
             )
         }.toImmutableList(),
         catalogItemModel = bindModel<CatalogItemModel>(offerModel = offerModel, itemIndex = itemIndex)?.properties,
+        transactionData = offerModel?.transactionData,
     )
 }
 

--- a/roktux/src/main/java/com/rokt/modelmapper/uimodel/LayoutSchemaUiModel.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/uimodel/LayoutSchemaUiModel.kt
@@ -189,6 +189,7 @@ sealed class LayoutSchemaUiModel(
         override val conditionalTransitionModifiers: ConditionalTransitionModifier?,
         override val children: ImmutableList<LayoutSchemaUiModel?>,
         val catalogItemModel: HMap?,
+        val transactionData: TransactionData?,
     ) : ButtonUiModel(ownModifiers, containerProperties, conditionalTransitionModifiers, children)
 
     data class CatalogDevicePayButtonUiModel(

--- a/roktux/src/main/java/com/rokt/roktux/component/button/CatalogResponseComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/CatalogResponseComponent.kt
@@ -36,9 +36,16 @@ internal class CatalogResponseComponent(
             onEventSent = onEventSent,
         ) {
             model.catalogItemModel?.let { catalogItemModel ->
-                onEventSent.invoke(
-                    LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected(catalogItemModel),
-                )
+                val event = if (model.transactionData?.isPartnerManagedPurchase == false) {
+                    LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
+                        offerId = offerState.currentOfferIndex,
+                        catalogItemModel = catalogItemModel,
+                        transactionData = model.transactionData,
+                    )
+                } else {
+                    LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected(catalogItemModel)
+                }
+                onEventSent.invoke(event)
             }
         }
     }

--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -107,6 +107,22 @@ sealed interface RoktUxEvent {
         val transactionData: TransactionData?,
         val onResult: (DevicePayResult) -> Unit,
     ) : RoktUxEvent
+
+    data class CartItemForwardPayment(
+        val layoutId: String,
+        val name: String,
+        val cartItemId: String,
+        val catalogItemId: String,
+        val currency: String,
+        val description: String,
+        val linkedProductId: String,
+        val providerData: String,
+        val totalPrice: Double,
+        val quantity: Int,
+        val unitPrice: Double,
+        val transactionData: TransactionData?,
+        val onResult: (DevicePayResult) -> Unit,
+    ) : RoktUxEvent
 }
 
 sealed interface DevicePayResult {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
@@ -36,6 +36,12 @@ internal class LayoutContract {
         data class OfferVisibilityChanged(val offerId: Int, val visible: Boolean) : LayoutEvent
         data class UiException(val throwable: Throwable, val closeLayout: Boolean) : LayoutEvent
         data class CartItemInstantPurchaseSelected(val catalogItemModel: HMap) : LayoutEvent
+        data class CartItemForwardPaymentSelected(
+            val offerId: Int,
+            val catalogItemModel: HMap,
+            val transactionData: TransactionData?,
+        ) : LayoutEvent
+
         data class CartItemDevicePaySelected(
             val offerId: Int,
             val catalogItemModel: HMap?,
@@ -45,6 +51,7 @@ internal class LayoutContract {
         ) : LayoutEvent
 
         data class CartItemDevicePayResultReceived(val offerId: Int, val result: DevicePayResult) : LayoutEvent
+        data class CartItemForwardPaymentResultReceived(val offerId: Int, val result: DevicePayResult) : LayoutEvent
     }
 
     sealed interface LayoutEffect : BaseContract.BaseEffect {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -332,12 +332,20 @@ internal class LayoutViewModel(
                 handleCartItemInstancePurchaseSelected(event.catalogItemModel)
             }
 
+            is LayoutContract.LayoutEvent.CartItemForwardPaymentSelected -> {
+                handleCartItemForwardPaymentSelected(event)
+            }
+
             is LayoutContract.LayoutEvent.CartItemDevicePaySelected -> {
                 handleCartItemDevicePaySelected(event)
             }
 
             is LayoutContract.LayoutEvent.CartItemDevicePayResultReceived -> {
                 handleCartItemDevicePayResult(event.offerId, event.result)
+            }
+
+            is LayoutContract.LayoutEvent.CartItemForwardPaymentResultReceived -> {
+                handleCartItemForwardPaymentResult(event.offerId, event.result)
             }
 
             else -> {}
@@ -433,6 +441,53 @@ internal class LayoutViewModel(
         setEvent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = false))
     }
 
+    private fun handleCartItemForwardPaymentSelected(event: LayoutContract.LayoutEvent.CartItemForwardPaymentSelected) {
+        with(event.catalogItemModel) {
+            val salePrice = get<Double>(KEY_PRICE) ?: get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
+            uxEvent(
+                RoktUxEvent.CartItemForwardPayment(
+                    layoutId = pluginId,
+                    name = get<String>(KEY_TITLE).orEmpty(),
+                    cartItemId = get<String>(KEY_CART_ITEM_ID).orEmpty(),
+                    catalogItemId = get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
+                    currency = get<String>(KEY_CURRENCY).orEmpty(),
+                    description = get<String>(KEY_DESCRIPTION).orEmpty(),
+                    linkedProductId = get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
+                    providerData = get<String>(KEY_PROVIDER_DATA).orEmpty(),
+                    totalPrice = salePrice,
+                    quantity = 1,
+                    unitPrice = salePrice,
+                    transactionData = event.transactionData,
+                    onResult = { result ->
+                        setEvent(
+                            LayoutContract.LayoutEvent.CartItemForwardPaymentResultReceived(
+                                event.offerId,
+                                result,
+                            ),
+                        )
+                    },
+                ),
+            )
+            handlePlatformEvent(
+                RoktPlatformEvent(
+                    eventType = EventType.SignalCartItemInstantPurchaseInitiated,
+                    sessionId = experienceModel.sessionId,
+                    parentGuid = get<String>(KEY_INSTANCE_GUID).orEmpty(),
+                    eventData = mapOf(
+                        KEY_CART_ITEM_ID to get<String>(KEY_CART_ITEM_ID).orEmpty(),
+                        KEY_CATALOG_ITEM_ID to get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
+                        KEY_CURRENCY to get<String>(KEY_CURRENCY).orEmpty(),
+                        KEY_DESCRIPTION to get<String>(KEY_DESCRIPTION).orEmpty(),
+                        KEY_LINKED_PRODUCT_ID to get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
+                        KEY_TOTAL_PRICE to salePrice.toString(),
+                        KEY_QUANTITY to "1",
+                        KEY_UNIT_PRICE to salePrice.toString(),
+                    ),
+                ),
+            )
+        }
+    }
+
     private fun handleCartItemDevicePaySelected(event: LayoutContract.LayoutEvent.CartItemDevicePaySelected) {
         if (!runtimeState.validationCoordinator.validate(event.validatorFieldKeys)) {
             return
@@ -492,6 +547,21 @@ internal class LayoutViewModel(
             is DevicePayResult.PendingConfirmation -> {
                 runtimeState.setCatalogRuntimeData(result.catalogRuntimeData)
                 updateOfferCustomState(offerId, DEVICE_PAY_STATE_CUSTOM_STATE_KEY, 1)
+            }
+        }
+        sendViewState()
+    }
+
+    private fun handleCartItemForwardPaymentResult(offerId: Int, result: DevicePayResult) {
+        when (result) {
+            DevicePayResult.Success -> updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, 1)
+
+            DevicePayResult.Failure,
+            DevicePayResult.Retry,
+            -> updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, -1)
+
+            is DevicePayResult.PendingConfirmation -> {
+                runtimeState.setCatalogRuntimeData(result.catalogRuntimeData)
             }
         }
         sendViewState()

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -406,86 +406,66 @@ internal class LayoutViewModel(
     }
 
     private fun handleCartItemInstancePurchaseSelected(catalogItemProperties: HMap) {
-        with(catalogItemProperties) {
-            uxEvent(
-                RoktUxEvent.CartItemInstantPurchase(
-                    layoutId = pluginId,
-                    cartItemId = get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                    catalogItemId = get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                    currency = get<String>(KEY_CURRENCY).orEmpty(),
-                    description = get<String>(KEY_DESCRIPTION).orEmpty(),
-                    linkedProductId = get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                    totalPrice = get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0,
-                    quantity = 1,
-                    unitPrice = get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0,
-                ),
-            )
-            handlePlatformEvent(
-                RoktPlatformEvent(
-                    eventType = EventType.SignalCartItemInstantPurchaseInitiated,
-                    sessionId = experienceModel.sessionId,
-                    parentGuid = get<String>("instanceGuid").orEmpty(),
-                    eventData = mapOf(
-                        KEY_CART_ITEM_ID to get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                        KEY_CATALOG_ITEM_ID to get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                        KEY_CURRENCY to get<String>(KEY_CURRENCY).orEmpty(),
-                        KEY_DESCRIPTION to get<String>(KEY_DESCRIPTION).orEmpty(),
-                        KEY_LINKED_PRODUCT_ID to get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                        KEY_TOTAL_PRICE to (get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0).toString(),
-                        KEY_QUANTITY to "1",
-                        KEY_UNIT_PRICE to (get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0).toString(),
-                    ),
-                ),
-            )
-        }
+        val originalPrice = catalogItemProperties.originalPrice()
+        uxEvent(
+            RoktUxEvent.CartItemInstantPurchase(
+                layoutId = pluginId,
+                cartItemId = catalogItemProperties.cartItemId(),
+                catalogItemId = catalogItemProperties.catalogItemId(),
+                currency = catalogItemProperties.currency(),
+                description = catalogItemProperties.description(),
+                linkedProductId = catalogItemProperties.linkedProductId(),
+                totalPrice = originalPrice,
+                quantity = 1,
+                unitPrice = originalPrice,
+            ),
+        )
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalCartItemInstantPurchaseInitiated,
+                sessionId = experienceModel.sessionId,
+                parentGuid = catalogItemProperties.instanceGuid(),
+                eventData = catalogItemProperties.cartItemEventData(originalPrice),
+            ),
+        )
         setEvent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = false))
     }
 
     private fun handleCartItemForwardPaymentSelected(event: LayoutContract.LayoutEvent.CartItemForwardPaymentSelected) {
-        with(event.catalogItemModel) {
-            val salePrice = get<Double>(KEY_PRICE) ?: get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
-            uxEvent(
-                RoktUxEvent.CartItemForwardPayment(
-                    layoutId = pluginId,
-                    name = get<String>(KEY_TITLE).orEmpty(),
-                    cartItemId = get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                    catalogItemId = get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                    currency = get<String>(KEY_CURRENCY).orEmpty(),
-                    description = get<String>(KEY_DESCRIPTION).orEmpty(),
-                    linkedProductId = get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                    providerData = get<String>(KEY_PROVIDER_DATA).orEmpty(),
-                    totalPrice = salePrice,
-                    quantity = 1,
-                    unitPrice = salePrice,
-                    transactionData = event.transactionData,
-                    onResult = { result ->
-                        setEvent(
-                            LayoutContract.LayoutEvent.CartItemForwardPaymentResultReceived(
-                                event.offerId,
-                                result,
-                            ),
-                        )
-                    },
-                ),
-            )
-            handlePlatformEvent(
-                RoktPlatformEvent(
-                    eventType = EventType.SignalCartItemInstantPurchaseInitiated,
-                    sessionId = experienceModel.sessionId,
-                    parentGuid = get<String>(KEY_INSTANCE_GUID).orEmpty(),
-                    eventData = mapOf(
-                        KEY_CART_ITEM_ID to get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                        KEY_CATALOG_ITEM_ID to get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                        KEY_CURRENCY to get<String>(KEY_CURRENCY).orEmpty(),
-                        KEY_DESCRIPTION to get<String>(KEY_DESCRIPTION).orEmpty(),
-                        KEY_LINKED_PRODUCT_ID to get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                        KEY_TOTAL_PRICE to salePrice.toString(),
-                        KEY_QUANTITY to "1",
-                        KEY_UNIT_PRICE to salePrice.toString(),
-                    ),
-                ),
-            )
-        }
+        val catalogItemProperties = event.catalogItemModel
+        val salePrice = catalogItemProperties.salePrice()
+        uxEvent(
+            RoktUxEvent.CartItemForwardPayment(
+                layoutId = pluginId,
+                name = catalogItemProperties.name(),
+                cartItemId = catalogItemProperties.cartItemId(),
+                catalogItemId = catalogItemProperties.catalogItemId(),
+                currency = catalogItemProperties.currency(),
+                description = catalogItemProperties.description(),
+                linkedProductId = catalogItemProperties.linkedProductId(),
+                providerData = catalogItemProperties.providerData(),
+                totalPrice = salePrice,
+                quantity = 1,
+                unitPrice = salePrice,
+                transactionData = event.transactionData,
+                onResult = { result ->
+                    setEvent(
+                        LayoutContract.LayoutEvent.CartItemForwardPaymentResultReceived(
+                            event.offerId,
+                            result,
+                        ),
+                    )
+                },
+            ),
+        )
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalCartItemInstantPurchaseInitiated,
+                sessionId = experienceModel.sessionId,
+                parentGuid = catalogItemProperties.instanceGuid(),
+                eventData = catalogItemProperties.cartItemEventData(salePrice),
+            ),
+        )
     }
 
     private fun handleCartItemDevicePaySelected(event: LayoutContract.LayoutEvent.CartItemDevicePaySelected) {
@@ -494,46 +474,35 @@ internal class LayoutViewModel(
         }
 
         val catalogItemProperties = event.catalogItemModel ?: return
-        with(catalogItemProperties) {
-            val salePrice = get<Double>(KEY_PRICE) ?: get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
-            uxEvent(
-                RoktUxEvent.CartItemDevicePay(
-                    layoutId = pluginId,
-                    name = get<String>(KEY_TITLE).orEmpty(),
-                    cartItemId = get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                    catalogItemId = get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                    currency = get<String>(KEY_CURRENCY).orEmpty(),
-                    description = get<String>(KEY_DESCRIPTION).orEmpty(),
-                    linkedProductId = get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                    providerData = get<String>(KEY_PROVIDER_DATA).orEmpty(),
-                    totalPrice = salePrice,
-                    quantity = 1,
-                    unitPrice = salePrice,
-                    paymentProvider = event.paymentProvider,
-                    transactionData = event.transactionData,
-                    onResult = { result ->
-                        setEvent(LayoutContract.LayoutEvent.CartItemDevicePayResultReceived(event.offerId, result))
-                    },
-                ),
-            )
-            handlePlatformEvent(
-                RoktPlatformEvent(
-                    eventType = EventType.SignalCartItemInstantPurchaseInitiated,
-                    sessionId = experienceModel.sessionId,
-                    parentGuid = get<String>(KEY_INSTANCE_GUID).orEmpty(),
-                    eventData = mapOf(
-                        KEY_CART_ITEM_ID to get<String>(KEY_CART_ITEM_ID).orEmpty(),
-                        KEY_CATALOG_ITEM_ID to get<String>(KEY_CATALOG_ITEM_ID).orEmpty(),
-                        KEY_CURRENCY to get<String>(KEY_CURRENCY).orEmpty(),
-                        KEY_DESCRIPTION to get<String>(KEY_DESCRIPTION).orEmpty(),
-                        KEY_LINKED_PRODUCT_ID to get<String>(KEY_LINKED_PRODUCT_ID).orEmpty(),
-                        KEY_TOTAL_PRICE to salePrice.toString(),
-                        KEY_QUANTITY to "1",
-                        KEY_UNIT_PRICE to salePrice.toString(),
-                    ),
-                ),
-            )
-        }
+        val salePrice = catalogItemProperties.salePrice()
+        uxEvent(
+            RoktUxEvent.CartItemDevicePay(
+                layoutId = pluginId,
+                name = catalogItemProperties.name(),
+                cartItemId = catalogItemProperties.cartItemId(),
+                catalogItemId = catalogItemProperties.catalogItemId(),
+                currency = catalogItemProperties.currency(),
+                description = catalogItemProperties.description(),
+                linkedProductId = catalogItemProperties.linkedProductId(),
+                providerData = catalogItemProperties.providerData(),
+                totalPrice = salePrice,
+                quantity = 1,
+                unitPrice = salePrice,
+                paymentProvider = event.paymentProvider,
+                transactionData = event.transactionData,
+                onResult = { result ->
+                    setEvent(LayoutContract.LayoutEvent.CartItemDevicePayResultReceived(event.offerId, result))
+                },
+            ),
+        )
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalCartItemInstantPurchaseInitiated,
+                sessionId = experienceModel.sessionId,
+                parentGuid = catalogItemProperties.instanceGuid(),
+                eventData = catalogItemProperties.cartItemEventData(salePrice),
+            ),
+        )
     }
 
     private fun handleCartItemDevicePayResult(offerId: Int, result: DevicePayResult) {
@@ -850,6 +819,37 @@ internal class LayoutViewModel(
 
     private fun LayoutRuntimeState.immutableOfferCustomStates() =
         allOfferCustomStates().mapValues { (_, value) -> value.toImmutableMap() }.toImmutableMap()
+
+    private fun HMap.name(): String = get<String>(KEY_TITLE).orEmpty()
+
+    private fun HMap.cartItemId(): String = get<String>(KEY_CART_ITEM_ID).orEmpty()
+
+    private fun HMap.catalogItemId(): String = get<String>(KEY_CATALOG_ITEM_ID).orEmpty()
+
+    private fun HMap.currency(): String = get<String>(KEY_CURRENCY).orEmpty()
+
+    private fun HMap.description(): String = get<String>(KEY_DESCRIPTION).orEmpty()
+
+    private fun HMap.linkedProductId(): String = get<String>(KEY_LINKED_PRODUCT_ID).orEmpty()
+
+    private fun HMap.providerData(): String = get<String>(KEY_PROVIDER_DATA).orEmpty()
+
+    private fun HMap.instanceGuid(): String = get<String>(KEY_INSTANCE_GUID).orEmpty()
+
+    private fun HMap.originalPrice(): Double = get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
+
+    private fun HMap.salePrice(): Double = get<Double>(KEY_PRICE) ?: originalPrice()
+
+    private fun HMap.cartItemEventData(price: Double): Map<String, String> = mapOf(
+        KEY_CART_ITEM_ID to cartItemId(),
+        KEY_CATALOG_ITEM_ID to catalogItemId(),
+        KEY_CURRENCY to currency(),
+        KEY_DESCRIPTION to description(),
+        KEY_LINKED_PRODUCT_ID to linkedProductId(),
+        KEY_TOTAL_PRICE to price.toString(),
+        KEY_QUANTITY to "1",
+        KEY_UNIT_PRICE to price.toString(),
+    )
 
     companion object {
         private const val KEY_INITIATOR = "initiator"

--- a/roktux/src/test/assets/CatalogResponseButtonComponent/CatalogResponseButton_with_Children.json
+++ b/roktux/src/test/assets/CatalogResponseButtonComponent/CatalogResponseButton_with_Children.json
@@ -1,0 +1,13 @@
+{
+  "type": "CatalogResponseButton",
+  "node": {
+    "children": [
+      {
+        "type": "BasicText",
+        "node": {
+          "value": "Confirm order"
+        }
+      }
+    ]
+  }
+}

--- a/roktux/src/test/assets/offer/Offer_with_forward_payment_catalog_item.json
+++ b/roktux/src/test/assets/offer/Offer_with_forward_payment_catalog_item.json
@@ -1,0 +1,56 @@
+{
+  "campaignId": "campaign-123",
+  "creative": {
+    "referralCreativeId": "creative-123",
+    "instanceGuid": "creative-instance-guid",
+    "token": "test",
+    "responseOptionsMap": {},
+    "copy": {},
+    "images": {},
+    "links": {},
+    "icons": {}
+  },
+  "catalogItems": [
+    {
+      "images": {},
+      "instanceGuid": "catalog-instance-guid-1",
+      "cartItemId": "cart-item-1",
+      "catalogItemId": "catalog-item-1",
+      "title": "Everyday sneakers",
+      "description": "Lightweight daily shoes",
+      "price": 79.99,
+      "originalPrice": 99.99,
+      "originalPriceFormatted": "$99.99",
+      "currency": "USD",
+      "signalType": "SignalResponse",
+      "url": "https://example.com/products/sneakers",
+      "minItemCount": 1,
+      "maxItemCount": 3,
+      "preSelectedQuantity": 1,
+      "providerData": "{\"merchant\":\"rokt\"}",
+      "urlBehavior": "External",
+      "linkedProductId": "linked-product-1",
+      "quantityMustBeSynchronized": false,
+      "positiveResponseText": "Add sneakers",
+      "negativeResponseText": "Skip sneakers",
+      "priceFormatted": "$79.99",
+      "addOnPluginUrl": "",
+      "addOnPluginName": "",
+      "token": "test"
+    }
+  ],
+  "transactionData": {
+    "paymentType": "Card",
+    "supportedPaymentMethods": [
+      {
+        "type": "CARD"
+      }
+    ],
+    "isPartnerManagedPurchase": false,
+    "partnerPaymentReference": "partner-reference",
+    "confirmationRef": "confirmation-ref",
+    "metadata": {
+      "merchant": "rokt"
+    }
+  }
+}

--- a/roktux/src/test/assets/offer/Offer_with_partner_managed_catalog_item.json
+++ b/roktux/src/test/assets/offer/Offer_with_partner_managed_catalog_item.json
@@ -1,0 +1,45 @@
+{
+  "campaignId": "campaign-123",
+  "creative": {
+    "referralCreativeId": "creative-123",
+    "instanceGuid": "creative-instance-guid",
+    "token": "test",
+    "responseOptionsMap": {},
+    "copy": {},
+    "images": {},
+    "links": {},
+    "icons": {}
+  },
+  "catalogItems": [
+    {
+      "images": {},
+      "instanceGuid": "catalog-instance-guid-1",
+      "cartItemId": "cart-item-1",
+      "catalogItemId": "catalog-item-1",
+      "title": "Everyday sneakers",
+      "description": "Lightweight daily shoes",
+      "price": 79.99,
+      "originalPrice": 99.99,
+      "originalPriceFormatted": "$99.99",
+      "currency": "USD",
+      "signalType": "SignalResponse",
+      "url": "https://example.com/products/sneakers",
+      "minItemCount": 1,
+      "maxItemCount": 3,
+      "preSelectedQuantity": 1,
+      "providerData": "{\"merchant\":\"rokt\"}",
+      "urlBehavior": "External",
+      "linkedProductId": "linked-product-1",
+      "quantityMustBeSynchronized": false,
+      "positiveResponseText": "Add sneakers",
+      "negativeResponseText": "Skip sneakers",
+      "priceFormatted": "$79.99",
+      "addOnPluginUrl": "",
+      "addOnPluginName": "",
+      "token": "test"
+    }
+  ],
+  "transactionData": {
+    "isPartnerManagedPurchase": true
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogResponseComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogResponseComponentTest.kt
@@ -1,0 +1,84 @@
+package com.rokt.roktux.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
+import com.rokt.core.testutils.annotations.DcuiConfig
+import com.rokt.core.testutils.annotations.DcuiNodeJson
+import com.rokt.core.testutils.annotations.DcuiOfferJson
+import com.rokt.modelmapper.hmap.get
+import com.rokt.roktux.testutil.BaseDcuiEspressoTest
+import com.rokt.roktux.viewmodel.layout.LayoutContract
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CatalogResponseComponentTest : BaseDcuiEspressoTest() {
+
+    @Test
+    @DcuiNodeJson(jsonFile = "CatalogResponseButtonComponent/CatalogResponseButton_with_Children.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_partner_managed_catalog_item.json")
+    fun testPartnerManagedPurchaseEmitsInstantPurchaseEvent() {
+        composeTestRule.onNodeWithText("Confirm order").assertIsDisplayed()
+
+        composeTestRule.waitForIdle()
+        dcuiComponentRule.capturedEvents.clear()
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).performClick()
+
+        val event = waitForInstantPurchaseEvent()
+
+        assertThat(event.catalogItemModel.get<String>("catalogItemId")).isEqualTo("catalog-item-1")
+        assertThat(getCapturedEvents().filterIsInstance<LayoutContract.LayoutEvent.CartItemForwardPaymentSelected>())
+            .isEmpty()
+    }
+
+    @Test
+    @DcuiNodeJson(jsonFile = "CatalogResponseButtonComponent/CatalogResponseButton_with_Children.json")
+    @DcuiConfig(testInInnerLayout = true)
+    @DcuiOfferJson(jsonFile = "offer/Offer_with_forward_payment_catalog_item.json")
+    fun testNonPartnerManagedPurchaseEmitsForwardPaymentEvent() {
+        composeTestRule.onNodeWithText("Confirm order").assertIsDisplayed()
+
+        composeTestRule.waitForIdle()
+        dcuiComponentRule.capturedEvents.clear()
+        composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).performClick()
+
+        val event = waitForForwardPaymentEvent()
+
+        assertThat(event.offerId).isEqualTo(0)
+        assertThat(event.catalogItemModel.get<String>("catalogItemId")).isEqualTo("catalog-item-1")
+        assertThat(event.transactionData?.isPartnerManagedPurchase).isFalse()
+        assertThat(event.transactionData?.partnerPaymentReference).isEqualTo("partner-reference")
+        assertThat(getCapturedEvents().filterIsInstance<LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected>())
+            .isEmpty()
+    }
+
+    private fun waitForInstantPurchaseEvent(): LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            getCapturedEvents().any { event ->
+                event is LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected
+            }
+        }
+
+        return getCapturedEvents()
+            .filterIsInstance<LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected>()
+            .first()
+    }
+
+    private fun waitForForwardPaymentEvent(): LayoutContract.LayoutEvent.CartItemForwardPaymentSelected {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            getCapturedEvents().any { event ->
+                event is LayoutContract.LayoutEvent.CartItemForwardPaymentSelected
+            }
+        }
+
+        return getCapturedEvents()
+            .filterIsInstance<LayoutContract.LayoutEvent.CartItemForwardPaymentSelected>()
+            .first()
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -22,6 +22,7 @@ import com.rokt.roktux.event.DevicePayResult
 import com.rokt.roktux.event.EventType
 import com.rokt.roktux.event.RoktPlatformEvent
 import com.rokt.roktux.event.RoktUxEvent
+import com.rokt.roktux.state.LayoutRuntimeState
 import com.rokt.roktux.validation.ValidationCoordinator
 import com.rokt.roktux.validation.ValidationStatus
 import com.rokt.roktux.viewmodel.base.BaseContract
@@ -459,6 +460,129 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `CartItemForwardPaymentSelected sends event with sale price transaction data and platform signal`() = runTest {
+        // Arrange
+        val transactionData = TransactionData(
+            paymentType = "Card",
+            supportedPaymentMethods = listOf(PaymentMethod("CARD")),
+            isPartnerManagedPurchase = false,
+            partnerPaymentReference = "partner-reference",
+        )
+        clearMocks(uxEvent, platformEvent, viewStateChange)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                transactionData = transactionData,
+            ),
+        )
+
+        // Assert
+        val event = captureForwardPaymentEvent()
+        assertThat(event.layoutId).isEqualTo("pluginId")
+        assertThat(event.name).isEqualTo("Everyday sneakers")
+        assertThat(event.cartItemId).isEqualTo("cart-item-1")
+        assertThat(event.catalogItemId).isEqualTo("catalog-item-1")
+        assertThat(event.currency).isEqualTo("USD")
+        assertThat(event.description).isEqualTo("Lightweight daily shoes")
+        assertThat(event.linkedProductId).isEqualTo("linked-product-1")
+        assertThat(event.providerData).isEqualTo("{\"merchant\":\"rokt\"}")
+        assertThat(event.totalPrice).isEqualTo(79.99)
+        assertThat(event.unitPrice).isEqualTo(79.99)
+        assertThat(event.transactionData).isEqualTo(transactionData)
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anyMatch {
+                        it.eventType == EventType.SignalCartItemInstantPurchaseInitiated &&
+                            it.parentGuid == "catalog-instance-guid-1" &&
+                            it.eventData?.get("totalPrice") == "79.99" &&
+                            it.eventData?.get("unitPrice") == "79.99"
+                    }
+                },
+            )
+        }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.any { it.eventType == EventType.SignalDismissal } })
+        }
+    }
+
+    @Test
+    fun `CartItemForwardPayment callback updates payment result custom state`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, viewStateChange)
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                transactionData = TransactionData(isPartnerManagedPurchase = false),
+            ),
+        )
+        val event = captureForwardPaymentEvent()
+
+        // Act
+        clearMocks(viewStateChange)
+        event.onResult(DevicePayResult.Success)
+
+        // Assert
+        verify(timeout = 2000) {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", 1)
+                },
+            )
+        }
+
+        // Act
+        clearMocks(viewStateChange)
+        event.onResult(DevicePayResult.Failure)
+
+        // Assert
+        verify(timeout = 2000) {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", -1)
+                },
+            )
+        }
+
+        // Act
+        clearMocks(viewStateChange)
+        event.onResult(DevicePayResult.Retry)
+
+        // Assert
+        verify(timeout = 2000) {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", -1)
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `CartItemForwardPayment pending confirmation stores catalog runtime data`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, viewStateChange)
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                transactionData = TransactionData(isPartnerManagedPurchase = false),
+            ),
+        )
+        val event = captureForwardPaymentEvent()
+
+        // Act
+        event.onResult(DevicePayResult.PendingConfirmation(mapOf("total" to "86.79")))
+
+        // Assert
+        assertThat(runtimeState().catalogRuntimeData()).containsEntry("total", "86.79")
+    }
+
+    @Test
     fun `CartItemDevicePaySelected sends event with sale price and platform signal`() = runTest {
         // Arrange
         val transactionData = TransactionData(
@@ -664,6 +788,20 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
             uxEvent.invoke(capture(eventSlot))
         }
         return eventSlot.captured as RoktUxEvent.CartItemDevicePay
+    }
+
+    private fun captureForwardPaymentEvent(): RoktUxEvent.CartItemForwardPayment {
+        val eventSlot = slot<RoktUxEvent>()
+        verify(timeout = 2000) {
+            uxEvent.invoke(capture(eventSlot))
+        }
+        return eventSlot.captured as RoktUxEvent.CartItemForwardPayment
+    }
+
+    private fun runtimeState(): LayoutRuntimeState {
+        val runtimeStateField = LayoutViewModel::class.java.getDeclaredField("runtimeState")
+        runtimeStateField.isAccessible = true
+        return runtimeStateField.get(layoutViewModel) as LayoutRuntimeState
     }
 
     private fun createCatalogItemProperties(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Android CatalogResponseButton currently always follows the instant purchase path. iOS routes partner-managed purchases to instant purchase and non-partner-managed purchases to forward payment based on transactionData.isPartnerManagedPurchase, so Android needs the forward path for shoppable Ads parity.

## What Has Changed

- Added `RoktUxEvent.CartItemForwardPayment` with catalog item details, transaction data, and a result callback.
- Threaded offer transaction data into `CatalogResponseButtonUiModel` and branched response button taps between instant purchase and forward payment.
- Added ViewModel handling for forward payment callbacks to update `paymentResult` and store pending confirmation catalog runtime data without closing the layout prematurely.
- Added component and ViewModel tests for partner-managed instant purchase, non-partner-managed forward payment, and forward payment result state.

## Screenshots/Video

- N/A - no visual changes. This changes CatalogResponseButton event behavior only.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local checks passed: `trunk check --ci`, `./gradlew test --no-daemon --max-workers=2 -Dkotlin.daemon.jvm.options="-Xmx1g"`, `./gradlew lint --no-daemon --max-workers=2`, and `./gradlew --no-daemon --max-workers=2 assembleDebug -Dkotlin.daemon.jvm.options="-Xmx1g"`.