### PR TITLE
ci(release): publish snapshots from workstation branches

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - workstation**
 
 permissions:
   contents: write
@@ -65,7 +66,9 @@ jobs:
 
   build-full-release:
     needs: setup-and-version
-    if: needs.setup-and-version.outputs.full_release_needed == 'true'
+    if: >
+      github.ref_name == 'main' &&
+      needs.setup-and-version.outputs.full_release_needed == 'true'
     runs-on: ubuntu-latest
     env:
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Snapshot versions are not published from workstation branches. Enable snapshot publishing, so that they can be consumed in the main SDK.

## What Has Changed

Enable the release publish workflow for workstation branch pushes so they generate snapshot artifacts.

Keep full release publishing limited to main when VERSION changes.

## Screenshots/Video

NA

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
