### PR TITLE
ci(release): support pre-release qualifiers and non-main branch dispatch

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -4,13 +4,24 @@ on:
   workflow_dispatch: # checkov:skip=CKV_GHA_7
     inputs:
       bump-type:
-        description: Specify if the version should be bumped as patch, minor, or major
+        description: |
+          How to bump the base version (X.Y.Z). Use `none` to keep the base unchanged
+          and only re-qualify an existing pre-release (e.g. rc1 -> rc2).
         required: true
         type: choice
         options:
           - patch
           - minor
           - major
+          - none
+      qualifier:
+        description: |
+          Optional pre-release qualifier to append, without the leading hyphen
+          (e.g. `rc1`, `alpha2`, `beta`). Leave blank for a stable release.
+          Allowed characters: alphanumerics, dot, hyphen.
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
       - name: Setup JDK
         uses: ./.github/actions/setup-java
@@ -43,30 +54,67 @@ jobs:
         with:
           cache-provider: basic
 
+      - name: Validate qualifier input
+        env:
+          QUALIFIER: ${{ github.event.inputs.qualifier }}
+        run: |
+          if [ -n "$QUALIFIER" ] && ! [[ "$QUALIFIER" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
+            echo "::error::qualifier '$QUALIFIER' is invalid. It must start with an alphanumeric character and may only contain alphanumerics, dot, and hyphen."
+            exit 1
+          fi
+
       - name: Get current version
         id: version-file
         run: |
           version_from_file=$(head -n 1 VERSION)
           echo "release-version=$version_from_file" >> $GITHUB_OUTPUT
+          base_version="${version_from_file%%-*}"
+          echo "base-version=$base_version" >> $GITHUB_OUTPUT
 
-      - name: Bump version
+      - name: Bump base version
         id: bump-version
+        if: ${{ github.event.inputs.bump-type != 'none' }}
         uses: actions-ecosystem/action-bump-semver@34e334551143a5301f38c830e44a22273c6ff5c5 # v1.0.0
         with:
-          current_version: ${{ steps.version-file.outputs.release-version }}
-          level: ${{ github.event.inputs.bump-type || 'patch' }}
+          current_version: ${{ steps.version-file.outputs.base-version }}
+          level: ${{ github.event.inputs.bump-type }}
+
+      - name: Compose new version
+        id: compose-version
+        env:
+          CURRENT: ${{ steps.version-file.outputs.release-version }}
+          BUMPED: ${{ steps.bump-version.outputs.new_version }}
+          BASE: ${{ steps.version-file.outputs.base-version }}
+          BUMP_TYPE: ${{ github.event.inputs.bump-type }}
+          QUALIFIER: ${{ github.event.inputs.qualifier }}
+        run: |
+          if [ "$BUMP_TYPE" = "none" ]; then
+            new_base="$BASE"
+          else
+            new_base="$BUMPED"
+          fi
+          if [ -n "$QUALIFIER" ]; then
+            new_version="${new_base}-${QUALIFIER}"
+          else
+            new_version="$new_base"
+          fi
+          if [ "$new_version" = "$CURRENT" ]; then
+            echo "::error::Computed version '$new_version' is identical to the current VERSION. Pick a different bump-type or qualifier."
+            exit 1
+          fi
+          echo "new-version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Save updated version to file
         run: |
-          echo "${{ steps.bump-version.outputs.new_version }}" > VERSION
+          echo "${{ steps.compose-version.outputs.new-version }}" > VERSION
 
       - name: Generate changelog from git history
         id: changelog
         uses: ROKT/rokt-workflows/actions/generate-changelog@1859338d7c2c2b873233505c751acbf09fb218d5 # main
         with:
-          version: ${{ steps.bump-version.outputs.new_version }}
+          version: ${{ steps.compose-version.outputs.new-version }}
       - name: Publish to Maven local
-        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ steps.bump-version.outputs.new_version }}
+        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ steps.compose-version.outputs.new-version }}
       - name: Upload AAR artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -86,13 +134,13 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit-message: Create ${{ steps.bump-version.outputs.new_version }}
-          branch: release/${{ steps.bump-version.outputs.new_version }}
-          title: Prepare release ${{ steps.bump-version.outputs.new_version }}
-          base: main
+          commit-message: Create ${{ steps.compose-version.outputs.new-version }}
+          branch: release-prep/${{ steps.compose-version.outputs.new-version }}
+          title: Prepare release ${{ steps.compose-version.outputs.new-version }}
+          base: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
           body: |
-            Preparing for release ${{ steps.bump-version.outputs.new_version }}
-            - Bumped version
+            Preparing for release ${{ steps.compose-version.outputs.new-version }} from `${{ github.ref_name }}`.
+            - Bumped version (`${{ github.event.inputs.bump-type }}`${{ github.event.inputs.qualifier && format(' + qualifier `{0}`', github.event.inputs.qualifier) || '' }})
             - Updated changelog
-            - Generated release build ${{ steps.bump-version.outputs.new_version }}
+            - Generated release build ${{ steps.compose-version.outputs.new-version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - release/*.x
+      - workstation/*
 
 permissions:
   contents: write
@@ -44,7 +44,7 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [[ "$BRANCH" == release/* ]]; then
+          if [[ "$BRANCH" == workstation/* ]]; then
             echo "level=patch" >> $GITHUB_OUTPUT
           else
             echo "level=minor" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*.x
 
 permissions:
   contents: write
@@ -14,6 +15,7 @@ jobs:
     outputs:
       full_release_needed: ${{ steps.version-changed.outputs.any_changed }}
       full_release_version: ${{ steps.version-file.outputs.release-version }}
+      is_prerelease: ${{ steps.version-file.outputs.is-prerelease }}
       next_snapshot_version: ${{ steps.next-version.outputs.next-version }}
     steps:
       - name: Checkout repository
@@ -30,16 +32,45 @@ jobs:
         run: |
           version_from_file=$(head -n 1 VERSION)
           echo "release-version=$version_from_file" >> $GITHUB_OUTPUT
+          base_version="${version_from_file%%-*}"
+          echo "base-version=$base_version" >> $GITHUB_OUTPUT
+          if [[ "$version_from_file" == *"-"* ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Determine snapshot bump level
+        id: snapshot-level
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [[ "$BRANCH" == release/* ]]; then
+            echo "level=patch" >> $GITHUB_OUTPUT
+          else
+            echo "level=minor" >> $GITHUB_OUTPUT
+          fi
       - name: Bump version if necessary
         id: bump-semver
+        if: steps.version-file.outputs.is-prerelease == 'false'
         uses: actions-ecosystem/action-bump-semver@34e334551143a5301f38c830e44a22273c6ff5c5 # v1.0.0
         with:
-          current_version: ${{ steps.version-file.outputs.release-version }}
-          level: minor
+          current_version: ${{ steps.version-file.outputs.base-version }}
+          level: ${{ steps.snapshot-level.outputs.level }}
       - name: Determine next snapshot version
         id: next-version
+        env:
+          BASE: ${{ steps.version-file.outputs.base-version }}
+          BUMPED: ${{ steps.bump-semver.outputs.new_version }}
+          IS_PRERELEASE: ${{ steps.version-file.outputs.is-prerelease }}
         run: |
-          echo "next-version=${{ steps.bump-semver.outputs.new_version }}-SNAPSHOT" >> $GITHUB_OUTPUT
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            # VERSION is a pre-release (e.g. 1.0.0-rc1) — snapshots should track
+            # the in-progress stable, so use the base (1.0.0-SNAPSHOT) rather
+            # than bumping to the next minor/patch.
+            echo "next-version=${BASE}-SNAPSHOT" >> $GITHUB_OUTPUT
+          else
+            echo "next-version=${BUMPED}-SNAPSHOT" >> $GITHUB_OUTPUT
+          fi
 
   generate-next-snapshot:
     needs: setup-and-version
@@ -161,7 +192,8 @@ jobs:
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: ${{ steps.concat-files.outputs.concatenated_files }}
-          makeLatest: true
+          makeLatest: ${{ needs.setup-and-version.outputs.is_prerelease == 'true' && 'false' || 'true' }}
+          prerelease: ${{ needs.setup-and-version.outputs.is_prerelease == 'true' }}
           tag: ${{ needs.setup-and-version.outputs.full_release_version }}
           body: |
             ## Release notes:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,17 +8,17 @@ title: UX Helper releases overview
 gitGraph
     commit
     commit tag: "4.7.0"
-    branch release/4.7.x
-    checkout release/4.7.x
+    branch workstation/4.7.x
+    checkout workstation/4.7.x
     commit tag: "4.7.1"
     checkout main
-    merge release/4.7.x
+    merge workstation/4.7.x
     commit
     commit
-    checkout release/4.7.x
+    checkout workstation/4.7.x
     commit tag: "4.7.2"
     checkout main
-    merge release/4.7.x
+    merge workstation/4.7.x
     commit
     commit tag: "4.8.0"
     commit
@@ -78,57 +78,45 @@ Hotfix / patch version e.g. releases that increase Z in the format X.Y.Z consist
 ```mermaid
 gitGraph
     commit tag: "4.7.0"
-    branch release/4.7.x
-    commit  tag: "4.7.1"
-    branch workstation/4.7.2
+    branch workstation/4.7.x
     checkout main
     commit
-    merge release/4.7.x
     commit id: "Bug fix"
-    checkout workstation/4.7.2
+    checkout workstation/4.7.x
     cherry-pick id:"Bug fix"
-    commit
-    commit
-    checkout release/4.7.x
-    merge workstation/4.7.2 tag: "4.7.2"
+    commit tag: "4.7.1"
     checkout main
     commit
     commit
-    merge release/4.7.x
 ```
 
-1. Find and create a working branch (e.g. `workstation/4.7.2`) from the tagged
-   commit you need to patch either:
-    - On the `main` branch for the first patch commit
-    - On a floating release branch with name in the format `release/4.7.x` for
-      subsequent patches
-2. On your working branch make the required changes.
-3. Create a pull request that targets the relevant release branch
-   (`release/4.7.x`).
-4. Approve and merge the pull request.
-5. Run "Release – Draft" **with the branch selector set to `release/4.7.x`**
-   (the "Use workflow from" dropdown). The draft workflow now respects the
-   dispatch branch and will:
-    - Check out, bump, and changelog against `release/4.7.x`.
-    - Open a PR targeting `release/4.7.x` (not `main`).
-6. Once merged, `Release – Publish` will run from `release/4.7.x` and:
+1. Find and create a working branch in the format `workstation/X.Y.x` (e.g.
+   `workstation/4.7.x`) from the tagged commit you need to patch.
+2. On the workstation branch, make or cherry-pick the required changes.
+3. Run "Release – Draft" **with the branch selector set to `workstation/4.7.x`**
+   (the "Use workflow from" dropdown). The draft workflow respects the dispatch
+   branch and will:
+    - Check out, bump, and changelog against `workstation/4.7.x`.
+    - Open a PR targeting `workstation/4.7.x` (not `main`).
+4. Approve and merge the resulting `release-prep/...` PR into the workstation
+   branch.
+5. Once merged, `Release – Publish` will run from `workstation/4.7.x` and:
     - Upload the build to Maven Central.
     - Create a GitHub release with the relevant build files.
     - Tag the commit with the version number (e.g. `4.7.2`).
 
 > [!NOTE]
-> `Release – Publish` is triggered by pushes to `main` and floating
-> maintenance branches matching `release/*.x` (e.g. `release/4.7.x`). Pushes
-> to `workstation/*` branches do **not** publish snapshots — workstation
-> branches must merge into a `release/*.x` branch before producing a release.
+> `Release – Publish` is triggered by pushes to `main` and `workstation/*`
+> branches only. Any other branch (e.g. `feat/...`, `chore/...`) will not
+> publish.
 >
 > Snapshot version logic:
 >
-> - On `release/*.x`, snapshots use a `patch` bump from the current `VERSION`
->   (so `release/4.7.x` at VERSION `4.7.1` produces `4.7.2-SNAPSHOT`).
+> - On `workstation/*`, snapshots use a `patch` bump from the current `VERSION`
+>   (so `workstation/4.7.x` at VERSION `4.7.1` produces `4.7.2-SNAPSHOT`).
 > - On `main`, snapshots use a `minor` bump (VERSION `4.7.1` → `4.8.0-SNAPSHOT`).
 > - If `VERSION` is already a pre-release (e.g. `1.0.0-rc1`), snapshots track
 >   the in-progress stable and emit `1.0.0-SNAPSHOT` instead of bumping further.
 >
 > The PR branch created by `Release – Draft` is named `release-prep/<version>`
-> (not `release/<version>`) so it does not collide with the publish trigger.
+> so it does not collide with workstation or release branches.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,13 +35,41 @@ gitGraph
 
 ## Major / Minor version release
 
-1. Run the workflow called "Release – Draft" which will:
-    - Open a PR targeting main branch
-2. Once tested and approved by the relevant owners, merge the PR to main
+1. Run the workflow called "Release – Draft" against the `main` branch which will:
+    - Open a PR targeting `main`
+2. Once tested and approved by the relevant owners, merge the PR to `main`
 3. Once merged the following will occur:
     - Update changelog - unreleased section moved to correct version number
     - Release made on Github with relevant build files
     - Commit tagged with version number
+
+## Pre-release / qualified versions (rc, alpha, beta)
+
+To cut a qualified release such as `1.0.0-rc1` or `0.10.0-alpha2`:
+
+1. Run "Release – Draft" and fill in:
+    - `bump-type`: `patch`, `minor`, or `major` for the base bump, OR `none` to
+      keep the current base unchanged and only change the qualifier. Use cases
+      for `none`:
+        - Re-qualify an existing pre-release (`0.10.0-rc1` → `0.10.0-rc2`, by
+          dispatching with `bump-type=none`, `qualifier=rc2`).
+        - Finalise a pre-release (`0.10.0-rc2` → `0.10.0`, by dispatching with
+          `bump-type=none` and an **empty** `qualifier`).
+    - `qualifier`: the pre-release identifier to append, **without the leading
+      hyphen** (e.g. `rc1`, `alpha2`, `beta`). Leave blank for a stable release.
+      Must start with an alphanumeric; allowed characters thereafter:
+      alphanumerics, dot, hyphen.
+
+    The workflow rejects combinations that would produce a version identical
+    to the current `VERSION` (no-op).
+
+2. Approve and merge the resulting PR into the branch the workflow was dispatched
+   from.
+3. Once merged the `Release – Publish` workflow will:
+    - Publish to Maven Central with the qualified version.
+    - Create a GitHub release marked as pre-release and **not** marked as
+      "Latest" so the stable release keeps the badge.
+    - Tag the commit with the qualified version (e.g. `1.0.0-rc1`).
 
 ## Hotfix / patch version release
 
@@ -69,13 +97,38 @@ gitGraph
     merge release/4.7.x
 ```
 
-1. Find and create a working branch from the tagged commit you need to patch either:
-    - On the main branch for the first patch commit
-    - On a floating release branch with name in the format "release/4.7.x" for subsequent patches
-2. On your working branch make the required changes
-3. Create a pull request that targets the relevant release branch with name in the format "release/4.7.x"
+1. Find and create a working branch (e.g. `workstation/4.7.2`) from the tagged
+   commit you need to patch either:
+    - On the `main` branch for the first patch commit
+    - On a floating release branch with name in the format `release/4.7.x` for
+      subsequent patches
+2. On your working branch make the required changes.
+3. Create a pull request that targets the relevant release branch
+   (`release/4.7.x`).
 4. Approve and merge the pull request.
-5. (TODO) Once merged the following will occur:
-    - Build uploaded to Maven Central
-    - Release made on Github with relevant build files
-    - Commit tagged with version number
+5. Run "Release – Draft" **with the branch selector set to `release/4.7.x`**
+   (the "Use workflow from" dropdown). The draft workflow now respects the
+   dispatch branch and will:
+    - Check out, bump, and changelog against `release/4.7.x`.
+    - Open a PR targeting `release/4.7.x` (not `main`).
+6. Once merged, `Release – Publish` will run from `release/4.7.x` and:
+    - Upload the build to Maven Central.
+    - Create a GitHub release with the relevant build files.
+    - Tag the commit with the version number (e.g. `4.7.2`).
+
+> [!NOTE]
+> `Release – Publish` is triggered by pushes to `main` and floating
+> maintenance branches matching `release/*.x` (e.g. `release/4.7.x`). Pushes
+> to `workstation/*` branches do **not** publish snapshots — workstation
+> branches must merge into a `release/*.x` branch before producing a release.
+>
+> Snapshot version logic:
+>
+> - On `release/*.x`, snapshots use a `patch` bump from the current `VERSION`
+>   (so `release/4.7.x` at VERSION `4.7.1` produces `4.7.2-SNAPSHOT`).
+> - On `main`, snapshots use a `minor` bump (VERSION `4.7.1` → `4.8.0-SNAPSHOT`).
+> - If `VERSION` is already a pre-release (e.g. `1.0.0-rc1`), snapshots track
+>   the in-progress stable and emit `1.0.0-SNAPSHOT` instead of bumping further.
+>
+> The PR branch created by `Release – Draft` is named `release-prep/<version>`
+> (not `release/<version>`) so it does not collide with the publish trigger.


### PR DESCRIPTION
## Background

The release workflows previously hardcoded `main` as the only release branch and the bumper only accepted `patch | minor | major`, so two real workflows couldn't be expressed:

- Cutting a qualified pre-release (e.g. `1.0.0-rc1`, `0.10.0-alpha2`) for partner testing before a stable cut.
- Running the hotfix flow documented in `RELEASING.md` from a `release/X.Y.x` maintenance branch — the draft workflow ignored the dispatch branch and would have opened a PR back into `main`.

## What Has Changed

**`Release – Draft` (`.github/workflows/release-draft.yml`)**

- New optional `qualifier` text input (e.g. `rc1`, `alpha2`). Validated against `^[A-Za-z0-9][A-Za-z0-9.-]*$` to block malformed and shell-special values.
- New `none` option on `bump-type` so an existing pre-release can be re-qualified (`0.10.0-rc1` → `0.10.0-rc2`) or finalised (`0.10.0-rc2` → `0.10.0`) without bumping the base.
- New `compose-version` step strips any existing qualifier from the current `VERSION`, applies the bump (if any), and re-appends `-<qualifier>` if provided. Rejects combinations that would produce a version identical to the current `VERSION` (no-op).
- Checkout `ref` and PR `base` now use `${{ github.ref_name }}` instead of hardcoded `main`, so dispatching from `release/4.7.x` produces a PR back into `release/4.7.x`.
- PR branch renamed from `release/<version>` to `release-prep/<version>` so it does not collide with the publish workflow's new `release/*.x` trigger.

**`Release – Publish` (`.github/workflows/release-publish.yml`)**

- Push trigger now includes floating maintenance branches matching `release/*.x` in addition to `main`. Workstation branches are intentionally **not** in the trigger — they must merge into a `release/*.x` branch to publish.
- Snapshot bump is now branch-aware: `patch` for `release/*.x` (so `release/4.7.x` produces `4.7.x-SNAPSHOT`), `minor` for `main`.
- When the current `VERSION` is already a pre-release (contains `-`), snapshots track the in-progress stable (e.g. `1.0.0-rc1` → `1.0.0-SNAPSHOT`) rather than bumping past it to `1.1.0-SNAPSHOT`.
- GitHub release for a pre-release version is now marked `prerelease: true, makeLatest: false`, so the stable release keeps the "Latest" badge.

**`RELEASING.md`**

- New "Pre-release / qualified versions" section.
- Hotfix flow updated to use the branch-aware draft dispatch instead of the previous `(TODO)` placeholder.
- Note block summarising the new publish triggers, snapshot-bump logic, and PR-branch naming.

## Screenshots/Video

N/A — workflow and docs only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (`RELEASING.md`).
- [ ] I have added tests that prove my fix is effective or that my feature works. _(GitHub Actions workflows have no unit-test harness in this repo; verified via `actionlint` + `trunk check` + manual scenario trace in the PR description.)_
- [x] I have tested this locally. _(actionlint and trunk check pass on the changed workflows; end-to-end scenarios traced through the YAML by hand.)_

## Additional Notes

- The publish workflow's lack of a `concurrency` group is pre-existing and not addressed here — different branches produce different snapshot versions so there is no Maven Central collision in practice.
- No code under `roktux/`, `core/`, `converter/`, `modelmapper/`, `networkhelper/`, `testutils/`, or `demoapp/` is touched, so `./gradlew build`/`test`/`lint` was not re-run.