### PR TITLE
feat(events): add shoppable ad interaction signals

### DIFF
--- a/demoapp/src/main/java/com/rokt/demoapp/ui/screen/tutorials/nine/TutorialNineViewModel.kt
+++ b/demoapp/src/main/java/com/rokt/demoapp/ui/screen/tutorials/nine/TutorialNineViewModel.kt
@@ -8,6 +8,7 @@ import com.rokt.demoapp.ui.state.UiContent
 import com.rokt.demoapp.ui.state.UiState
 import com.rokt.networkhelper.data.RoktNetwork
 import com.rokt.networkhelper.model.ExperienceRequest
+import com.rokt.roktux.event.DevicePayResult
 import com.rokt.roktux.event.RoktUxEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -63,22 +64,45 @@ class TutorialNineViewModel @Inject constructor() : ViewModel() {
 
     fun handleUXEvent(event: RoktUxEvent) {
         viewModelScope.launch {
-            if (event is RoktUxEvent.CartItemInstantPurchase) {
-                _state.value = UiState(loading = true)
-                try {
-                    withContext(Dispatchers.IO) {
-                        delay(5000)
-                        // Simulate a failure scenario 1 out of 5 times
-                        val random = Random.nextInt(5)
-                        if (random == 0) {
-                            throw Exception("Purchase failed")
+            when (event) {
+                is RoktUxEvent.CartItemInstantPurchase -> {
+                    _state.value = UiState(loading = true)
+                    try {
+                        withContext(Dispatchers.IO) {
+                            delay(5000)
+                            // Simulate a failure scenario 1 out of 5 times
+                            val random = Random.nextInt(5)
+                            if (random == 0) {
+                                throw Exception("Purchase failed")
+                            }
                         }
+                        _state.value = UiState(data = UiContent.PaymentSuccessContent("Purchase completed"))
+                    } catch (e: Exception) {
+                        _state.value = UiState(data = UiContent.PaymentFailureContent(e.message.orEmpty()))
                     }
-                    _state.value = UiState(data = UiContent.PaymentSuccessContent("Purchase completed"))
-                } catch (e: Exception) {
-                    _state.value = UiState(data = UiContent.PaymentFailureContent(e.message.orEmpty()))
                 }
+
+                is RoktUxEvent.CartItemDevicePay -> event.onResult(dummyPaymentResult())
+
+                is RoktUxEvent.CartItemForwardPayment -> event.onResult(dummyPaymentResult())
+
+                else -> Unit
             }
         }
+    }
+
+    private fun dummyPaymentResult(): DevicePayResult = when (Random.nextInt(3)) {
+        0 -> DevicePayResult.Success
+
+        1 -> DevicePayResult.Failure
+
+        else -> DevicePayResult.PendingConfirmation(
+            mapOf(
+                "subtotal" to "79.99",
+                "tax" to "6.60",
+                "shipping" to "0.00",
+                "total" to "86.59",
+            ),
+        )
     }
 }

--- a/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
@@ -46,6 +46,8 @@ import com.rokt.modelmapper.uimodel.ModifierProperties
 import com.rokt.modelmapper.uimodel.StateBlock
 import com.rokt.modelmapper.utils.ROKT_ICONS_FONT_FAMILY
 import com.rokt.roktux.di.layout.LocalLayoutComponent
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.validation.ValidationCoordinator
 import com.rokt.roktux.validation.ValidationStatus
 import com.rokt.roktux.viewmodel.layout.LayoutContract
@@ -192,6 +194,7 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                                 onSelected = { optionIndex ->
                                     val updatedSelections =
                                         selectedIndices(model, offerState) + (model.attributeIndex to optionIndex)
+                                    val activeItemIndex = resolveActiveCatalogItemIndex(model, updatedSelections)
                                     pendingSelectedIndex = optionIndex
                                     onEventSent(
                                         LayoutContract.LayoutEvent.SetCustomState(
@@ -199,8 +202,16 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                                             optionIndex,
                                         ),
                                     )
-                                    resolveActiveCatalogItemIndex(model, updatedSelections)?.let { activeItemIndex ->
+                                    activeItemIndex?.let {
                                         onEventSent(LayoutContract.LayoutEvent.SetActiveCatalogItem(activeItemIndex))
+                                        onEventSent(
+                                            LayoutContract.LayoutEvent.UserInteractionSelected(
+                                                offerId = offerState.currentOfferIndex,
+                                                action = RoktUserInteractionAction.DropDownItemSelected,
+                                                context = RoktUserInteractionContext.CatalogDropDown,
+                                                catalogItemIndex = activeItemIndex,
+                                            ),
+                                        )
                                     }
                                     isExpanded = false
                                     if (validationFieldKey != null &&

--- a/roktux/src/main/java/com/rokt/roktux/component/CatalogImageGalleryComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CatalogImageGalleryComponent.kt
@@ -20,7 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -34,6 +36,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.modelmapper.utils.ROKT_ICONS_FONT_FAMILY
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
 
@@ -104,10 +108,29 @@ internal class CatalogImageGalleryComponent(
             contentAlignment = BiasAlignment(container.arrangementBias, container.alignmentBias),
         ) {
             val pagerState = rememberPagerState { galleryImages.size }
+            val isScrollInProgress = pagerState.isScrollInProgress
+            var scrollStartPage by remember { mutableStateOf<Int?>(null) }
+            var explicitNavigationTargetPage by remember { mutableStateOf<Int?>(null) }
+            var stateSyncTargetPage by remember { mutableStateOf<Int?>(null) }
 
-            fun navigateToPage(targetPage: Int) {
+            fun sendUserInteraction(action: RoktUserInteractionAction) {
+                onEventSent(
+                    LayoutContract.LayoutEvent.UserInteractionSelected(
+                        offerId = offerState.currentOfferIndex,
+                        action = action,
+                        context = RoktUserInteractionContext.CatalogImageGallery,
+                        catalogItemIndex = offerState.activeCatalogItemIndex,
+                    ),
+                )
+            }
+
+            fun navigateToPage(targetPage: Int, action: RoktUserInteractionAction? = null) {
                 val page = targetPage.coerceIn(0, galleryImages.lastIndex)
                 if (page != pagerState.currentPage) {
+                    action?.let {
+                        explicitNavigationTargetPage = page
+                        sendUserInteraction(it)
+                    }
                     onEventSent(
                         LayoutContract.LayoutEvent.SetCustomState(
                             model.customStateKey,
@@ -117,8 +140,38 @@ internal class CatalogImageGalleryComponent(
                 }
             }
 
+            LaunchedEffect(isScrollInProgress) {
+                if (isScrollInProgress) {
+                    scrollStartPage = pagerState.currentPage
+                } else {
+                    val startPage = scrollStartPage
+                    val endPage = pagerState.currentPage
+                    if (startPage != null &&
+                        endPage != startPage &&
+                        endPage != explicitNavigationTargetPage &&
+                        endPage != stateSyncTargetPage
+                    ) {
+                        sendUserInteraction(
+                            if (endPage > startPage) {
+                                RoktUserInteractionAction.MainImageSwipeLeft
+                            } else {
+                                RoktUserInteractionAction.MainImageSwipeRight
+                            },
+                        )
+                    }
+                    scrollStartPage = null
+                    if (explicitNavigationTargetPage == endPage) {
+                        explicitNavigationTargetPage = null
+                    }
+                    if (stateSyncTargetPage == endPage) {
+                        stateSyncTargetPage = null
+                    }
+                }
+            }
+
             LaunchedEffect(selectedPage, galleryImages.size) {
                 if (pagerState.currentPage != selectedPage) {
+                    stateSyncTargetPage = selectedPage
                     pagerState.requestScrollToPage(selectedPage)
                 }
             }
@@ -139,8 +192,18 @@ internal class CatalogImageGalleryComponent(
                 state = pagerState,
                 modifier = Modifier.catalogGalleryTapNavigation(
                     enabled = pagerState.pageCount > 1,
-                    onTapBackward = { navigateToPage(pagerState.currentPage - 1) },
-                    onTapForward = { navigateToPage(pagerState.currentPage + 1) },
+                    onTapBackward = {
+                        navigateToPage(
+                            pagerState.currentPage - 1,
+                            RoktUserInteractionAction.MainImageScrollIconLeftClick,
+                        )
+                    },
+                    onTapForward = {
+                        navigateToPage(
+                            pagerState.currentPage + 1,
+                            RoktUserInteractionAction.MainImageScrollIconRightClick,
+                        )
+                    },
                 ),
                 flingBehavior = PagerDefaults.flingBehavior(
                     state = pagerState,
@@ -166,8 +229,18 @@ internal class CatalogImageGalleryComponent(
                 breakpointIndex = breakpointIndex,
                 offerState = offerState,
                 onEventSent = onEventSent,
-                onBackwardSelected = { navigateToPage(pagerState.currentPage - 1) },
-                onForwardSelected = { navigateToPage(pagerState.currentPage + 1) },
+                onBackwardSelected = {
+                    navigateToPage(
+                        pagerState.currentPage - 1,
+                        RoktUserInteractionAction.MainImageScrollIconLeftClick,
+                    )
+                },
+                onForwardSelected = {
+                    navigateToPage(
+                        pagerState.currentPage + 1,
+                        RoktUserInteractionAction.MainImageScrollIconRightClick,
+                    )
+                },
             )
 
             if (model.showIndicators && pagerState.pageCount > 1 && model.indicatorStyle != null) {
@@ -179,7 +252,9 @@ internal class CatalogImageGalleryComponent(
                     offerState = offerState,
                     isDarkModeEnabled = isDarkModeEnabled,
                     breakpointIndex = breakpointIndex,
-                    onIndicatorSelected = ::navigateToPage,
+                    onIndicatorSelected = { page ->
+                        navigateToPage(page, RoktUserInteractionAction.ThumbnailClick)
+                    },
                 )
             }
         }

--- a/roktux/src/main/java/com/rokt/roktux/component/CatalogImageGalleryComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CatalogImageGalleryComponent.kt
@@ -20,9 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -109,9 +107,7 @@ internal class CatalogImageGalleryComponent(
         ) {
             val pagerState = rememberPagerState { galleryImages.size }
             val isScrollInProgress = pagerState.isScrollInProgress
-            var scrollStartPage by remember { mutableStateOf<Int?>(null) }
-            var explicitNavigationTargetPage by remember { mutableStateOf<Int?>(null) }
-            var stateSyncTargetPage by remember { mutableStateOf<Int?>(null) }
+            val swipeTracker = remember { CatalogImageGallerySwipeTracker() }
 
             fun sendUserInteraction(action: RoktUserInteractionAction) {
                 onEventSent(
@@ -128,7 +124,7 @@ internal class CatalogImageGalleryComponent(
                 val page = targetPage.coerceIn(0, galleryImages.lastIndex)
                 if (page != pagerState.currentPage) {
                     action?.let {
-                        explicitNavigationTargetPage = page
+                        swipeTracker.markExplicitNavigationTarget(page)
                         sendUserInteraction(it)
                     }
                     onEventSent(
@@ -140,38 +136,17 @@ internal class CatalogImageGalleryComponent(
                 }
             }
 
-            LaunchedEffect(isScrollInProgress) {
-                if (isScrollInProgress) {
-                    scrollStartPage = pagerState.currentPage
-                } else {
-                    val startPage = scrollStartPage
-                    val endPage = pagerState.currentPage
-                    if (startPage != null &&
-                        endPage != startPage &&
-                        endPage != explicitNavigationTargetPage &&
-                        endPage != stateSyncTargetPage
-                    ) {
-                        sendUserInteraction(
-                            if (endPage > startPage) {
-                                RoktUserInteractionAction.MainImageSwipeLeft
-                            } else {
-                                RoktUserInteractionAction.MainImageSwipeRight
-                            },
-                        )
-                    }
-                    scrollStartPage = null
-                    if (explicitNavigationTargetPage == endPage) {
-                        explicitNavigationTargetPage = null
-                    }
-                    if (stateSyncTargetPage == endPage) {
-                        stateSyncTargetPage = null
-                    }
-                }
+            LaunchedEffect(isScrollInProgress, pagerState.currentPage) {
+                swipeTracker.onPagerScrollChanged(
+                    isScrollInProgress = isScrollInProgress,
+                    settledPage = pagerState.settledPage,
+                    currentPage = pagerState.currentPage,
+                )?.let(::sendUserInteraction)
             }
 
             LaunchedEffect(selectedPage, galleryImages.size) {
                 if (pagerState.currentPage != selectedPage) {
-                    stateSyncTargetPage = selectedPage
+                    swipeTracker.markStateSyncTarget(selectedPage)
                     pagerState.requestScrollToPage(selectedPage)
                 }
             }
@@ -483,5 +458,60 @@ internal class CatalogImageGalleryComponent(
     private companion object {
         const val PreviousImageContentDescription = "Previous image"
         const val NextImageContentDescription = "Next image"
+    }
+}
+
+internal class CatalogImageGallerySwipeTracker {
+    private var scrollStartPage: Int? = null
+    private var explicitNavigationTargetPage: Int? = null
+    private var stateSyncTargetPage: Int? = null
+
+    fun markExplicitNavigationTarget(page: Int) {
+        explicitNavigationTargetPage = page
+    }
+
+    fun markStateSyncTarget(page: Int) {
+        stateSyncTargetPage = page
+    }
+
+    fun onPagerScrollChanged(
+        isScrollInProgress: Boolean,
+        settledPage: Int,
+        currentPage: Int,
+    ): RoktUserInteractionAction? {
+        if (isScrollInProgress) {
+            if (scrollStartPage == null) {
+                scrollStartPage = settledPage
+            }
+            return null
+        }
+
+        val startPage = scrollStartPage
+        val action = if (startPage != null &&
+            currentPage != startPage &&
+            currentPage != explicitNavigationTargetPage &&
+            currentPage != stateSyncTargetPage
+        ) {
+            if (currentPage > startPage) {
+                RoktUserInteractionAction.MainImageSwipeLeft
+            } else {
+                RoktUserInteractionAction.MainImageSwipeRight
+            }
+        } else {
+            null
+        }
+
+        scrollStartPage = null
+        clearConsumedTargets(currentPage)
+        return action
+    }
+
+    private fun clearConsumedTargets(page: Int) {
+        if (explicitNavigationTargetPage == page) {
+            explicitNavigationTargetPage = null
+        }
+        if (stateSyncTargetPage == page) {
+            stateSyncTargetPage = null
+        }
     }
 }

--- a/roktux/src/main/java/com/rokt/roktux/component/button/CloseButtonComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/CloseButtonComponent.kt
@@ -40,7 +40,10 @@ internal class CloseButtonComponent(
             onEventSent = onEventSent,
         ) {
             onEventSent.invoke(
-                LayoutContract.LayoutEvent.CloseSelected(isDismissed = false),
+                LayoutContract.LayoutEvent.CloseSelected(
+                    isDismissed = false,
+                    dismissalMethod = model.dismissalMethod,
+                ),
             )
         }
     }

--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -140,6 +140,7 @@ data class RoktPlatformEvent(
     @SerialName("pageInstanceGuid") val pageInstanceGuid: String = "",
     @SerialName("eventTime") val eventTime: String = roktDateFormat.format(Date()),
     @SerialName("eventData") val eventData: Map<String, String>? = null,
+    @SerialName("objectData") val objectData: Map<String, String>? = null,
     @SerialName("metadata") var metadata: List<EventNameValue> = emptyList(),
 ) : RoktEvent {
     init {
@@ -186,10 +187,32 @@ enum class EventType {
 
     @SerialName("SignalCartItemInstantPurchaseInitiated")
     SignalCartItemInstantPurchaseInitiated,
+
+    @SerialName("SignalInstantPurchaseDismissal")
+    SignalInstantPurchaseDismissal,
+
+    @SerialName("SignalUserInteraction")
+    SignalUserInteraction,
 }
 
 @Serializable
 data class EventNameValue(@SerialName("name") val name: String, @SerialName("value") val value: String)
+
+internal enum class RoktUserInteractionAction {
+    ValidationTriggerFailed,
+    DropDownItemSelected,
+    ThumbnailClick,
+    MainImageScrollIconLeftClick,
+    MainImageScrollIconRightClick,
+    MainImageSwipeLeft,
+    MainImageSwipeRight,
+}
+
+internal enum class RoktUserInteractionContext {
+    CustomStateValidationTriggerButton,
+    CatalogDropDown,
+    CatalogImageGallery,
+}
 
 internal fun SignalType.toEventType(): EventType = when (this) {
     SignalType.SignalResponse -> EventType.SignalResponse

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutContract.kt
@@ -5,6 +5,8 @@ import com.rokt.modelmapper.uimodel.OpenLinks
 import com.rokt.modelmapper.uimodel.TransactionData
 import com.rokt.network.model.PaymentProvider
 import com.rokt.roktux.event.DevicePayResult
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.viewmodel.base.BaseContract
 
 internal class LayoutContract {
@@ -15,7 +17,7 @@ internal class LayoutContract {
         object LayoutInteractive : LayoutEvent
         object FirstOfferLoaded : LayoutEvent
         object UserInteracted : LayoutEvent
-        data class CloseSelected(val isDismissed: Boolean) : LayoutEvent
+        data class CloseSelected(val isDismissed: Boolean, val dismissalMethod: String? = null) : LayoutEvent
         data class ResponseOptionSelected(
             val currentOffer: Int,
             val openLinks: OpenLinks,
@@ -36,6 +38,14 @@ internal class LayoutContract {
         data class OfferVisibilityChanged(val offerId: Int, val visible: Boolean) : LayoutEvent
         data class UiException(val throwable: Throwable, val closeLayout: Boolean) : LayoutEvent
         data class CartItemInstantPurchaseSelected(val catalogItemModel: HMap) : LayoutEvent
+        data class UserInteractionSelected(
+            val offerId: Int,
+            val action: RoktUserInteractionAction,
+            val context: RoktUserInteractionContext,
+            val catalogItemIndex: Int? = null,
+            val parentGuid: String? = null,
+        ) : LayoutEvent
+
         data class CartItemForwardPaymentSelected(
             val offerId: Int,
             val catalogItemModel: HMap,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -27,6 +27,8 @@ import com.rokt.roktux.event.DevicePayResult
 import com.rokt.roktux.event.EventNameValue
 import com.rokt.roktux.event.EventType
 import com.rokt.roktux.event.RoktPlatformEvent
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.event.RoktUxEvent
 import com.rokt.roktux.event.UrlEventState
 import com.rokt.roktux.event.toEventType
@@ -249,7 +251,11 @@ internal class LayoutViewModel(
             }
 
             is LayoutContract.LayoutEvent.CloseSelected -> {
-                sendDismissEvent(if (event.isDismissed) DISMISSED else CLOSE_BUTTON)
+                if (event.dismissalMethod == INSTANT_PURCHASE_DISMISSED) {
+                    sendInstantPurchaseDismissalEvent(event.dismissalMethod)
+                } else {
+                    sendDismissEvent(if (event.isDismissed) DISMISSED else CLOSE_BUTTON)
+                }
                 setEffect {
                     LayoutContract.LayoutEffect.CloseLayout(
                         onClose = {
@@ -330,6 +336,10 @@ internal class LayoutViewModel(
 
             is LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected -> {
                 handleCartItemInstancePurchaseSelected(event.catalogItemModel)
+            }
+
+            is LayoutContract.LayoutEvent.UserInteractionSelected -> {
+                handleUserInteractionSelected(event)
             }
 
             is LayoutContract.LayoutEvent.CartItemForwardPaymentSelected -> {
@@ -470,6 +480,11 @@ internal class LayoutViewModel(
 
     private fun handleCartItemDevicePaySelected(event: LayoutContract.LayoutEvent.CartItemDevicePaySelected) {
         if (!runtimeState.validationCoordinator.validate(event.validatorFieldKeys)) {
+            sendUserInteractionEvent(
+                parentGuid = event.catalogItemModel?.instanceGuid().orEmpty(),
+                action = RoktUserInteractionAction.ValidationTriggerFailed,
+                context = RoktUserInteractionContext.CustomStateValidationTriggerButton,
+            )
             return
         }
 
@@ -534,6 +549,36 @@ internal class LayoutViewModel(
             }
         }
         sendViewState()
+    }
+
+    private fun handleUserInteractionSelected(event: LayoutContract.LayoutEvent.UserInteractionSelected) {
+        val parentGuid = event.parentGuid
+            ?: event.catalogItemIndex?.let { index -> catalogItemInstanceGuid(event.offerId, index) }
+            ?: return
+        sendUserInteractionEvent(
+            parentGuid = parentGuid,
+            action = event.action,
+            context = event.context,
+        )
+    }
+
+    private fun sendUserInteractionEvent(
+        parentGuid: String,
+        action: RoktUserInteractionAction,
+        context: RoktUserInteractionContext,
+    ) {
+        if (parentGuid.isBlank()) return
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalUserInteraction,
+                sessionId = experienceModel.sessionId,
+                parentGuid = parentGuid,
+                objectData = mapOf(
+                    KEY_USER_INTERACTION_ACTION to action.name,
+                    KEY_USER_INTERACTION_CONTEXT to context.name,
+                ),
+            ),
+        )
     }
 
     private fun handleResponseOptionSelected(
@@ -677,6 +722,17 @@ internal class LayoutViewModel(
         handlePlatformEvent(
             RoktPlatformEvent(
                 eventType = EventType.SignalDismissal,
+                sessionId = experienceModel.sessionId,
+                parentGuid = pluginModel.instanceGuid,
+                metadata = listOf(EventNameValue(KEY_INITIATOR, dismissReason)),
+            ),
+        )
+    }
+
+    private fun sendInstantPurchaseDismissalEvent(dismissReason: String) {
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalInstantPurchaseDismissal,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
                 metadata = listOf(EventNameValue(KEY_INITIATOR, dismissReason)),
@@ -836,6 +892,14 @@ internal class LayoutViewModel(
 
     private fun HMap.instanceGuid(): String = get<String>(KEY_INSTANCE_GUID).orEmpty()
 
+    private fun catalogItemInstanceGuid(offerId: Int, catalogItemIndex: Int): String? = pluginModel.slots
+        .getOrNull(offerId)
+        ?.offer
+        ?.catalogItems
+        ?.getOrNull(catalogItemIndex)
+        ?.properties
+        ?.instanceGuid()
+
     private fun HMap.originalPrice(): Double = get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
 
     private fun HMap.salePrice(): Double = get<Double>(KEY_PRICE) ?: originalPrice()
@@ -853,6 +917,8 @@ internal class LayoutViewModel(
 
     companion object {
         private const val KEY_INITIATOR = "initiator"
+        private const val KEY_USER_INTERACTION_ACTION = "action"
+        private const val KEY_USER_INTERACTION_CONTEXT = "context"
         private const val KEY_PAGE_RENDER_ENGINE = "pageRenderEngine"
         private const val KEY_PAGE_SIGNAL_LOAD_START = "pageSignalLoadStart"
         private const val KEY_PAGE_SIGNAL_LOAD_COMPLETE = "pageSignalLoadComplete"
@@ -861,6 +927,7 @@ internal class LayoutViewModel(
         private const val NO_MORE_OFFERS_TO_SHOW = "NO_MORE_OFFERS_TO_SHOW"
         private const val DISMISSED = "DISMISSED"
         private const val CLOSE_BUTTON = "CLOSE_BUTTON"
+        private const val INSTANT_PURCHASE_DISMISSED = "INSTANT_PURCHASE_DISMISSED"
         private const val LOCATION_TARGET_ELEMENT_DOES_NOT_MATCH =
             "Plugin targetElementSelector does not match the location"
         private const val QUEUE_CAPACITY = 20

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
@@ -22,6 +22,8 @@ import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
 import com.rokt.core.testutils.annotations.DcuiConfig
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.core.testutils.annotations.DcuiOfferJson
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
 import com.rokt.roktux.validation.ValidationCoordinator
 import com.rokt.roktux.viewmodel.layout.LayoutContract
@@ -153,6 +155,12 @@ class CatalogDropdownComponentTest : BaseDcuiEspressoTest() {
                 ),
             ) && getCapturedEvents().contains(LayoutContract.LayoutEvent.SetActiveCatalogItem(index = 1))
         }
+        assertThat(getCapturedEvents().filterIsInstance<LayoutContract.LayoutEvent.UserInteractionSelected>())
+            .anySatisfy { event ->
+                assertThat(event.action).isEqualTo(RoktUserInteractionAction.DropDownItemSelected)
+                assertThat(event.context).isEqualTo(RoktUserInteractionContext.CatalogDropDown)
+                assertThat(event.catalogItemIndex).isEqualTo(1)
+            }
     }
 
     @Test

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogImageGalleryComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogImageGalleryComponentTest.kt
@@ -16,8 +16,11 @@ import com.rokt.core.testutils.annotations.DcuiConfig
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.core.testutils.annotations.DcuiOfferJson
 import com.rokt.core.testutils.assertion.assertBackgroundColor
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
 import com.rokt.roktux.viewmodel.layout.LayoutContract
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -34,6 +37,9 @@ class CatalogImageGalleryComponentTest : BaseDcuiEspressoTest() {
             .assertWidthIsEqualTo(180.dp)
             .assertHeightIsEqualTo(140.dp)
             .assertBackgroundColor("#eef7ff")
+
+        assertThat(getCapturedEvents())
+            .noneMatch { event -> event is LayoutContract.LayoutEvent.UserInteractionSelected }
     }
 
     @Test
@@ -50,6 +56,7 @@ class CatalogImageGalleryComponentTest : BaseDcuiEspressoTest() {
             }
 
         waitForImageCarouselPosition(2)
+        waitForGalleryInteraction(RoktUserInteractionAction.MainImageScrollIconRightClick)
     }
 
     @Test
@@ -65,12 +72,24 @@ class CatalogImageGalleryComponentTest : BaseDcuiEspressoTest() {
             .performClick()
 
         waitForImageCarouselPosition(2)
+        waitForGalleryInteraction(RoktUserInteractionAction.MainImageScrollIconRightClick)
     }
 
     private fun waitForImageCarouselPosition(position: Int) {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             getCapturedEvents().any { event ->
                 event == LayoutContract.LayoutEvent.SetCustomState("imageCarouselPosition", position)
+            }
+        }
+    }
+
+    private fun waitForGalleryInteraction(action: RoktUserInteractionAction) {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            getCapturedEvents().any { event ->
+                event is LayoutContract.LayoutEvent.UserInteractionSelected &&
+                    event.action == action &&
+                    event.context == RoktUserInteractionContext.CatalogImageGallery &&
+                    event.catalogItemIndex == 0
             }
         }
     }

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogImageGallerySwipeTrackerTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogImageGallerySwipeTrackerTest.kt
@@ -1,0 +1,91 @@
+package com.rokt.roktux.component
+
+import com.rokt.roktux.event.RoktUserInteractionAction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CatalogImageGallerySwipeTrackerTest {
+
+    @Test
+    fun `clears explicit target after non-scrolling page jump`() {
+        val tracker = CatalogImageGallerySwipeTracker()
+
+        tracker.markExplicitNavigationTarget(1)
+        tracker.markStateSyncTarget(1)
+
+        assertThat(
+            tracker.onPagerScrollChanged(
+                isScrollInProgress = false,
+                settledPage = 1,
+                currentPage = 1,
+            ),
+        ).isNull()
+
+        tracker.onPagerScrollChanged(
+            isScrollInProgress = true,
+            settledPage = 0,
+            currentPage = 0,
+        )
+
+        assertThat(
+            tracker.onPagerScrollChanged(
+                isScrollInProgress = false,
+                settledPage = 1,
+                currentPage = 1,
+            ),
+        ).isEqualTo(RoktUserInteractionAction.MainImageSwipeLeft)
+    }
+
+    @Test
+    fun `suppresses scrolling page jumps only once`() {
+        val tracker = CatalogImageGallerySwipeTracker()
+
+        tracker.markStateSyncTarget(1)
+        tracker.onPagerScrollChanged(
+            isScrollInProgress = true,
+            settledPage = 0,
+            currentPage = 0,
+        )
+
+        assertThat(
+            tracker.onPagerScrollChanged(
+                isScrollInProgress = false,
+                settledPage = 1,
+                currentPage = 1,
+            ),
+        ).isNull()
+
+        tracker.onPagerScrollChanged(
+            isScrollInProgress = true,
+            settledPage = 0,
+            currentPage = 0,
+        )
+
+        assertThat(
+            tracker.onPagerScrollChanged(
+                isScrollInProgress = false,
+                settledPage = 1,
+                currentPage = 1,
+            ),
+        ).isEqualTo(RoktUserInteractionAction.MainImageSwipeLeft)
+    }
+
+    @Test
+    fun `reports swipe direction from scroll start and end page`() {
+        val tracker = CatalogImageGallerySwipeTracker()
+
+        tracker.onPagerScrollChanged(
+            isScrollInProgress = true,
+            settledPage = 1,
+            currentPage = 1,
+        )
+
+        assertThat(
+            tracker.onPagerScrollChanged(
+                isScrollInProgress = false,
+                settledPage = 0,
+                currentPage = 0,
+            ),
+        ).isEqualTo(RoktUserInteractionAction.MainImageSwipeRight)
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/event/RoktPlatformEventTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/event/RoktPlatformEventTest.kt
@@ -1,0 +1,29 @@
+package com.rokt.roktux.event
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RoktPlatformEventTest {
+
+    @Test
+    fun `RoktPlatformEvent serializes objectData`() {
+        val event = RoktPlatformEvent(
+            eventType = EventType.SignalUserInteraction,
+            sessionId = "session-id",
+            parentGuid = "catalog-instance-guid",
+            objectData = mapOf(
+                "action" to "ThumbnailClick",
+                "context" to "CatalogImageGallery",
+            ),
+        )
+
+        val json = Json.parseToJsonElement(event.toJsonString()).jsonObject
+        val objectData = json.getValue("objectData").jsonObject
+
+        assertEquals("ThumbnailClick", objectData.getValue("action").jsonPrimitive.content)
+        assertEquals("CatalogImageGallery", objectData.getValue("context").jsonPrimitive.content)
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -6,6 +6,8 @@ import com.rokt.modelmapper.hmap.TypedKey
 import com.rokt.modelmapper.hmap.set
 import com.rokt.modelmapper.mappers.ModelMapper
 import com.rokt.modelmapper.uimodel.Action
+import com.rokt.modelmapper.uimodel.CatalogImageWrapperModel
+import com.rokt.modelmapper.uimodel.CatalogItemModel
 import com.rokt.modelmapper.uimodel.LayoutSettings
 import com.rokt.modelmapper.uimodel.OpenLinks
 import com.rokt.modelmapper.uimodel.OptionsModel
@@ -21,6 +23,8 @@ import com.rokt.roktux.component.evaluatePredicates
 import com.rokt.roktux.event.DevicePayResult
 import com.rokt.roktux.event.EventType
 import com.rokt.roktux.event.RoktPlatformEvent
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.event.RoktUxEvent
 import com.rokt.roktux.state.LayoutRuntimeState
 import com.rokt.roktux.validation.ValidationCoordinator
@@ -68,6 +72,19 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                                 every { creative } returns mockk(relaxed = true) {
                                     every { instanceGuid } returns "creativeInstanceGuid"
                                 }
+                                every { catalogItems } returns persistentListOf(
+                                    CatalogItemModel(
+                                        properties = createCatalogItemProperties(),
+                                        imageWrapper = CatalogImageWrapperModel(HMap()),
+                                    ),
+                                    CatalogItemModel(
+                                        properties = createCatalogItemProperties(
+                                            instanceGuid = "catalog-instance-guid-2",
+                                            catalogItemId = "catalog-item-2",
+                                        ),
+                                        imageWrapper = CatalogImageWrapperModel(HMap()),
+                                    ),
+                                )
                             }
                         },
                         mockk(relaxed = true) {
@@ -743,6 +760,147 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         verify(exactly = 0, timeout = 500) {
             uxEvent.invoke(match { event -> event is RoktUxEvent.CartItemDevicePay })
         }
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
+                        assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.objectData).isEqualTo(
+                            mapOf(
+                                "action" to "ValidationTriggerFailed",
+                                "context" to "CustomStateValidationTriggerButton",
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `UserInteractionSelected sends SignalUserInteraction with object data`() = runTest {
+        // Arrange
+        clearMocks(platformEvent)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.UserInteractionSelected(
+                offerId = 0,
+                action = RoktUserInteractionAction.ThumbnailClick,
+                context = RoktUserInteractionContext.CatalogImageGallery,
+                parentGuid = "catalog-instance-guid-1",
+            ),
+        )
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
+                        assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.objectData).isEqualTo(
+                            mapOf(
+                                "action" to "ThumbnailClick",
+                                "context" to "CatalogImageGallery",
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `UserInteractionSelected resolves catalog item parent guid from index`() = runTest {
+        // Arrange
+        clearMocks(platformEvent)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.UserInteractionSelected(
+                offerId = 0,
+                action = RoktUserInteractionAction.DropDownItemSelected,
+                context = RoktUserInteractionContext.CatalogDropDown,
+                catalogItemIndex = 1,
+            ),
+        )
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
+                        assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-2")
+                        assertThat(platformEvent.objectData).isEqualTo(
+                            mapOf(
+                                "action" to "DropDownItemSelected",
+                                "context" to "CatalogDropDown",
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `CloseSelected with instant purchase dismissal method sends SignalInstantPurchaseDismissal`() = runTest {
+        // Arrange
+        clearMocks(platformEvent)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CloseSelected(
+                isDismissed = false,
+                dismissalMethod = "INSTANT_PURCHASE_DISMISSED",
+            ),
+        )
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalInstantPurchaseDismissal)
+                        assertThat(platformEvent.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(platformEvent.metadata)
+                            .anySatisfy { metadata ->
+                                assertThat(metadata.name).isEqualTo("initiator")
+                                assertThat(metadata.value).isEqualTo("INSTANT_PURCHASE_DISMISSED")
+                            }
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `CloseSelected without instant purchase dismissal method still sends SignalDismissal`() = runTest {
+        // Arrange
+        clearMocks(platformEvent)
+
+        // Act
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = false))
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalDismissal)
+                        assertThat(platformEvent.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(platformEvent.metadata)
+                            .anySatisfy { metadata ->
+                                assertThat(metadata.name).isEqualTo("initiator")
+                                assertThat(metadata.value).isEqualTo("CLOSE_BUTTON")
+                            }
+                    }
+                },
+            )
+        }
     }
 
     @Test
@@ -805,13 +963,15 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     private fun createCatalogItemProperties(
+        instanceGuid: String = "catalog-instance-guid-1",
+        catalogItemId: String = "catalog-item-1",
         price: Double = 79.99,
         originalPrice: Double = 99.99,
     ): HMap = HMap().apply {
-        set(TypedKey<String>("instanceGuid"), "catalog-instance-guid-1")
+        set(TypedKey<String>("instanceGuid"), instanceGuid)
         set(TypedKey<String>("title"), "Everyday sneakers")
         set(TypedKey<String>("cartItemId"), "cart-item-1")
-        set(TypedKey<String>("catalogItemId"), "catalog-item-1")
+        set(TypedKey<String>("catalogItemId"), catalogItemId)
         set(TypedKey<String>("currency"), "USD")
         set(TypedKey<String>("description"), "Lightweight daily shoes")
         set(TypedKey<String>("linkedProductId"), "linked-product-1")


### PR DESCRIPTION
## Background

- Shoppable ads need UXHelper Android to emit the same interaction and dismissal platform signals as the other UXHelper clients. This adds the missing UXHelper-owned events while keeping SDK-owned public payment APIs and terminal purchase reporting outside this repository.

## What Has Changed

- Added `SignalUserInteraction` and `SignalInstantPurchaseDismissal` platform event types with `objectData` serialization support.
- Added UXHelper-local user interaction action and context types.
- Emitted user interaction signals for device-pay validation failures, catalog dropdown selections, and catalog image gallery interactions.
- Carried close button `dismissalMethod` into close handling and emitted instant-purchase dismissal signals for `INSTANT_PURCHASE_DISMISSED`.
- Added demo app dummy handlers for device-pay and forward-payment UX events so result states can be exercised.
- Added focused tests for user interaction payloads, dismissal behavior, dropdown/gallery event dispatch, and `objectData` serialization.

## Screenshots/Video

- N/A - no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Forward payment terminal purchase reporting remains SDK/server-owned.
- SDK follow-up planning was written separately at `/Users/thomson/conductor/workspaces/sdk-android-source/san-jose-v2/.context/design/shoppable-events-consumer-plan.md`.