### PR TITLE
fix(roktux): resolve offer-scoped custom state in When predicates

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/WhenComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/WhenComponent.kt
@@ -129,7 +129,14 @@ internal fun evaluatePredicates(
             }
 
             is WhenUiPredicate.CustomState -> {
-                offerState.customState[predicate.key] ?: 0
+                // Resolve against the effective custom state for the current offer:
+                // offer-scoped value first, then global fallback, then 0 (mirrors the iOS
+                // PredicateHandling.customStatePredicatesMatched local-then-global resolution).
+                // Without the offer-scoped lookup, results written per-offer (e.g. the device-pay
+                // `paymentResult`) are never observed by `When` nodes and the success branch never shows.
+                offerState.offerCustomStates[currentOffer.toString()]?.get(predicate.key)
+                    ?: offerState.customState[predicate.key]
+                    ?: 0
             }
 
             is WhenUiPredicate.DomainState -> {

--- a/roktux/src/test/java/com/rokt/roktux/component/WhenComponentEvaluationTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/WhenComponentEvaluationTest.kt
@@ -1363,6 +1363,85 @@ class WhenComponentEvaluationTest {
         )
     }
 
+    @Test
+    fun `given a custom state set only as an offer-scoped state for the current offer, when the When reads it, then evaluate resolves the offer value`() {
+        // Regression: the device-pay result is written to OFFER-scoped state (updateOfferCustomState),
+        // e.g. paymentResult=1 at offer 0. Without offer-scoped resolution the success branch never shows.
+        val offerState = createOfferUiState(
+            currentOfferIndex = 0,
+            offerCustomStates = persistentMapOf("0" to persistentMapOf("paymentResult" to 1)),
+        )
+
+        assertTrue(
+            evaluatePredicate(
+                WhenUiPredicate.CustomState(condition = OrderableWhenUiCondition.Is, key = "paymentResult", value = 1),
+                offerState = offerState,
+            ),
+        )
+    }
+
+    @Test
+    fun `given an offer-scoped custom state whose value does not match, then evaluate returns false`() {
+        val offerState = createOfferUiState(
+            currentOfferIndex = 0,
+            offerCustomStates = persistentMapOf("0" to persistentMapOf("paymentResult" to -1)),
+        )
+
+        assertFalse(
+            evaluatePredicate(
+                WhenUiPredicate.CustomState(condition = OrderableWhenUiCondition.Is, key = "paymentResult", value = 1),
+                offerState = offerState,
+            ),
+        )
+    }
+
+    @Test
+    fun `given an offer-scoped custom state set for a different offer, when the current offer has no value, then evaluate defaults to zero`() {
+        // Offer 1's paymentResult must not leak into offer 0's When evaluation.
+        val offerState = createOfferUiState(
+            currentOfferIndex = 0,
+            offerCustomStates = persistentMapOf("1" to persistentMapOf("paymentResult" to 1)),
+        )
+
+        assertFalse(
+            evaluatePredicate(
+                WhenUiPredicate.CustomState(condition = OrderableWhenUiCondition.Is, key = "paymentResult", value = 1),
+                offerState = offerState,
+            ),
+        )
+    }
+
+    @Test
+    fun `given the same key set both offer-scoped and global, when the When reads it, then the offer-scoped value takes precedence`() {
+        val offerState = createOfferUiState(
+            currentOfferIndex = 0,
+            customState = persistentMapOf("paymentResult" to -1),
+            offerCustomStates = persistentMapOf("0" to persistentMapOf("paymentResult" to 1)),
+        )
+
+        assertTrue(
+            evaluatePredicate(
+                WhenUiPredicate.CustomState(condition = OrderableWhenUiCondition.Is, key = "paymentResult", value = 1),
+                offerState = offerState,
+            ),
+        )
+    }
+
+    @Test
+    fun `given a custom state set only as a global state, when there is no offer-scoped value, then evaluate falls back to the global value`() {
+        val offerState = createOfferUiState(
+            currentOfferIndex = 0,
+            customState = persistentMapOf("globalFlag" to 1),
+        )
+
+        assertTrue(
+            evaluatePredicate(
+                WhenUiPredicate.CustomState(condition = OrderableWhenUiCondition.Is, key = "globalFlag", value = 1),
+                offerState = offerState,
+            ),
+        )
+    }
+
     private fun evaluatePredicate(
         vararg predicate: WhenUiPredicate,
         offerState: OfferUiState = createOfferUiState(),
@@ -1374,15 +1453,20 @@ class WhenComponentEvaluationTest {
     )
 
     private fun createOfferUiState(
+        currentOfferIndex: Int = 0,
         domainStates: kotlinx.collections.immutable.ImmutableMap<String, Int> = persistentMapOf(),
+        customState: kotlinx.collections.immutable.ImmutableMap<String, Int> = persistentMapOf(),
+        offerCustomStates: kotlinx.collections.immutable.ImmutableMap<String, kotlinx.collections.immutable.ImmutableMap<String, Int>> =
+            persistentMapOf(),
     ): OfferUiState = OfferUiState(
-        currentOfferIndex = 0,
+        currentOfferIndex = currentOfferIndex,
         lastOfferIndex = 1,
         viewableItems = 1,
         creativeCopy = persistentMapOf(),
         breakpoints = persistentMapOf(),
-        customState = persistentMapOf(),
+        customState = customState,
         domainStates = domainStates,
+        offerCustomStates = offerCustomStates,
     )
 
     private fun createWhenUiModel(vararg predicate: WhenUiPredicate): LayoutSchemaUiModel.WhenUiModel = LayoutSchemaUiModel.WhenUiModel(


### PR DESCRIPTION
## Background

- Catalog/shoppable device-pay offers set the `paymentResult` custom state when a `DevicePayResult` callback resolves, and a `When` node is expected to react to it and reveal the success state. This never happened — the success UI stayed hidden after a successful device payment.
- Root cause: the device-pay/forward-payment result is written to **offer-scoped** custom state (`updateOfferCustomState`, e.g. `paymentResult=1` at the current offer), but the `When` predicate evaluator only read the layout-wide (global) `customState`. The value was set correctly but never observed, so the predicate always resolved to `0`.

## What Has Changed

- `WhenComponent.evaluatePredicates` now resolves a `CustomState` predicate against the effective custom state for the current offer: offer-scoped value first, then global fallback, then `0`. This matches the iOS UX Helper resolution (`PredicateHandling.customStatePredicatesMatched`).
- Added regression tests in `WhenComponentEvaluationTest` covering offer-scoped resolution, value mismatch, no cross-offer leakage, offer-over-global precedence, and global fallback.

## Screenshots/Video

- Device-pay success flow (Playground → select variant → Buy with GooglePay): the success state ("Thank you for your purchase!") now renders after the result callback. Verified on an Android emulator.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Backward compatible: layouts using only global custom state have an empty offer-scoped map for the current offer, so resolution falls through to the previous behavior.