### PR TITLE
fix(catalog-dropdown): align option list with dropdown header

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/CatalogDropdownComponent.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -83,7 +82,6 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
         var boxBounds by remember { mutableStateOf<IntRect?>(null) }
         var headBounds by remember { mutableStateOf<IntRect?>(null) }
         var popupPlacement by remember { mutableStateOf(CatalogDropdownPopupPlacement.Below) }
-        var popupWindowOffset by remember { mutableStateOf(IntOffset.Zero) }
         val headBoundsInBox = remember(headBounds, boxBounds) {
             headBounds?.let { bounds ->
                 boxBounds?.let(bounds::relativeTo)
@@ -91,7 +89,6 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
         }
         val density = LocalDensity.current
         val layoutDirection = LocalLayoutDirection.current
-        val view = LocalView.current
         val showValidationError = validationStatus == ValidationStatus.INVALID
         val rootContainer = modifierFactory.createContainerUiProperties(
             containerProperties = model.containerProperties,
@@ -146,7 +143,6 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                     onPositioned = { coordinates, padding ->
                         val bounds = coordinates.boundsInWindowIntRect()
                             .inflate(padding = padding, density = density, layoutDirection = layoutDirection)
-                        popupWindowOffset = view.windowToScreenOffset()
                         headSize = IntSize(width = bounds.width, height = bounds.height)
                         headBounds = bounds
                     },
@@ -159,12 +155,10 @@ internal class CatalogDropdownComponent(private val modifierFactory: ModifierFac
                         popupPositionProvider = remember(
                             headSize.height,
                             headBoundsInBox,
-                            popupWindowOffset,
                         ) {
                             CatalogDropdownPopupPositionProvider(
                                 anchorHeight = headSize.height,
                                 measuredAnchorBoundsInParent = headBoundsInBox,
-                                windowOffset = popupWindowOffset,
                                 onPlacementCalculated = { placement ->
                                     popupPlacement = placement
                                 },
@@ -751,10 +745,9 @@ private val CatalogDropdownPopupPlacement.borderCornerRadiusMode: BorderCornerRa
         CatalogDropdownPopupPlacement.Below -> BorderCornerRadiusMode.Bottom
     }
 
-private class CatalogDropdownPopupPositionProvider(
+internal class CatalogDropdownPopupPositionProvider(
     private val anchorHeight: Int,
     private val measuredAnchorBoundsInParent: IntRect?,
-    private val windowOffset: IntOffset,
     private val onPlacementCalculated: (CatalogDropdownPopupPlacement) -> Unit,
 ) : PopupPositionProvider {
     override fun calculatePosition(
@@ -778,19 +771,8 @@ private class CatalogDropdownPopupPositionProvider(
             windowSize = windowSize,
             popupContentSize = popupContentSize,
             layoutDirection = layoutDirection,
-        ) + windowOffset
+        )
     }
-}
-
-private fun android.view.View.windowToScreenOffset(): IntOffset {
-    val locationOnScreen = IntArray(2)
-    val locationInWindow = IntArray(2)
-    getLocationOnScreen(locationOnScreen)
-    getLocationInWindow(locationInWindow)
-    return IntOffset(
-        x = locationOnScreen[0] - locationInWindow[0],
-        y = locationOnScreen[1] - locationInWindow[1],
-    )
 }
 
 private fun IntRect.toWindowBounds(parentBounds: IntRect): IntRect = IntRect(

--- a/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/CatalogDropdownComponentTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
@@ -135,6 +136,32 @@ class CatalogDropdownComponentTest : BaseDcuiEspressoTest() {
                 popupContentSize = popupSize,
             ),
         )
+    }
+
+    @Test
+    fun testCatalogDropdownPopupPositionProviderUsesWindowCoordinates() {
+        var popupPlacement: CatalogDropdownPopupPlacement? = null
+        val provider = CatalogDropdownPopupPositionProvider(
+            anchorHeight = 44,
+            measuredAnchorBoundsInParent = IntRect(
+                offset = IntOffset(5, 12),
+                size = IntSize(width = 220, height = 44),
+            ),
+            onPlacementCalculated = { popupPlacement = it },
+        )
+
+        val popupOffset = provider.calculatePosition(
+            anchorBounds = IntRect(
+                offset = IntOffset(20, 100),
+                size = IntSize(width = 300, height = 44),
+            ),
+            windowSize = IntSize(width = 400, height = 500),
+            layoutDirection = LayoutDirection.Ltr,
+            popupContentSize = IntSize(width = 220, height = 120),
+        )
+
+        assertEquals(IntOffset(25, 156), popupOffset)
+        assertEquals(CatalogDropdownPopupPlacement.Below, popupPlacement)
     }
 
     @Test


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Catalog dropdown options could render too far below the dropdown header on device because popup positioning mixed window-relative and screen-relative coordinates. This made the list appear separated from its header in layouts with system bar offsets, even though snapshot tests did not show the gap.

## What Has Changed

- Removed the extra screen-coordinate offset from catalog dropdown popup positioning.
- Kept the popup anchored to the measured dropdown header bounds in window coordinates.
- Added a regression test for popup positioning when the dropdown parent is already offset in the window.

## Screenshots/Video

- Please attach before/after media before merge. Local emulator verification confirmed the option list now opens directly below the dropdown header.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified with `trunk check --ci`, `./gradlew build test lint`, and `./gradlew :roktux:testDebugUnitTest -PrunSnapshotTests --tests com.rokt.roktux.snapshot.CatalogDropdownSnapshotTest`.
