### PR TITLE
fix(roktux): send device-pay purchase terminal events

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -188,6 +188,12 @@ enum class EventType {
     @SerialName("SignalCartItemInstantPurchaseInitiated")
     SignalCartItemInstantPurchaseInitiated,
 
+    @SerialName("SignalCartItemInstantPurchase")
+    SignalCartItemInstantPurchase,
+
+    @SerialName("SignalCartItemInstantPurchaseFailure")
+    SignalCartItemInstantPurchaseFailure,
+
     @SerialName("SignalInstantPurchaseDismissal")
     SignalInstantPurchaseDismissal,
 

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -86,6 +86,7 @@ internal class LayoutViewModel(
 
     private val _eventsQueue = MutableSharedFlow<RoktPlatformEvent>(replay = 5)
     private val _sentEvents = mutableSetOf<RoktPlatformEvent>()
+    private var pendingDevicePayCatalogItem: PendingDevicePayCatalogItem? = null
 
     init {
         // The buffer is a queue with max capacity of 20 and interval 25ms.
@@ -490,6 +491,16 @@ internal class LayoutViewModel(
 
         val catalogItemProperties = event.catalogItemModel ?: return
         val salePrice = catalogItemProperties.salePrice()
+        pendingDevicePayCatalogItem = catalogItemProperties.toPendingDevicePayCatalogItem()
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = EventType.SignalCartItemInstantPurchaseInitiated,
+                sessionId = experienceModel.sessionId,
+                parentGuid = catalogItemProperties.instanceGuid(),
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
+                objectData = catalogItemProperties.cartItemObjectData(),
+            ),
+        )
         uxEvent(
             RoktUxEvent.CartItemDevicePay(
                 layoutId = pluginId,
@@ -510,30 +521,42 @@ internal class LayoutViewModel(
                 },
             ),
         )
-        handlePlatformEvent(
-            RoktPlatformEvent(
-                eventType = EventType.SignalCartItemInstantPurchaseInitiated,
-                sessionId = experienceModel.sessionId,
-                parentGuid = catalogItemProperties.instanceGuid(),
-                eventData = catalogItemProperties.cartItemEventData(salePrice),
-            ),
-        )
     }
 
     private fun handleCartItemDevicePayResult(offerId: Int, result: DevicePayResult) {
         when (result) {
-            DevicePayResult.Success -> updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, 1)
+            DevicePayResult.Success -> {
+                updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, 1)
+                sendDevicePayTerminalEvent(EventType.SignalCartItemInstantPurchase)
+            }
 
             DevicePayResult.Failure,
             DevicePayResult.Retry,
-            -> updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, -1)
+            -> {
+                updateOfferCustomState(offerId, PAYMENT_RESULT_CUSTOM_STATE_KEY, -1)
+                sendDevicePayTerminalEvent(EventType.SignalCartItemInstantPurchaseFailure)
+            }
 
             is DevicePayResult.PendingConfirmation -> {
                 runtimeState.setCatalogRuntimeData(result.catalogRuntimeData)
                 updateOfferCustomState(offerId, DEVICE_PAY_STATE_CUSTOM_STATE_KEY, 1)
+                pendingDevicePayCatalogItem = null
             }
         }
         sendViewState()
+    }
+
+    private fun sendDevicePayTerminalEvent(eventType: EventType) {
+        val catalogItem = pendingDevicePayCatalogItem ?: return
+        pendingDevicePayCatalogItem = null
+        handlePlatformEvent(
+            RoktPlatformEvent(
+                eventType = eventType,
+                sessionId = experienceModel.sessionId,
+                parentGuid = catalogItem.instanceGuid,
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
+            ),
+        )
     }
 
     private fun handleCartItemForwardPaymentResult(offerId: Int, result: DevicePayResult) {
@@ -914,6 +937,16 @@ internal class LayoutViewModel(
         KEY_QUANTITY to "1",
         KEY_UNIT_PRICE to price.toString(),
     )
+
+    private fun HMap.cartItemObjectData(): Map<String, String> = mapOf(
+        KEY_CATALOG_ITEM_ID to catalogItemId(),
+        KEY_QUANTITY to "1",
+    )
+
+    private fun HMap.toPendingDevicePayCatalogItem(): PendingDevicePayCatalogItem =
+        PendingDevicePayCatalogItem(instanceGuid = instanceGuid())
+
+    private data class PendingDevicePayCatalogItem(val instanceGuid: String)
 
     companion object {
         private const val KEY_INITIATOR = "initiator"

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -529,7 +529,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     @Test
     fun `CartItemForwardPayment callback updates payment result custom state`() = runTest {
         // Arrange
-        clearMocks(uxEvent, viewStateChange)
+        clearMocks(uxEvent, platformEvent, viewStateChange)
         layoutViewModel.setEvent(
             LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
                 offerId = 0,
@@ -540,7 +540,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         val event = captureForwardPaymentEvent()
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Success)
 
         // Assert
@@ -551,9 +551,12 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                 },
             )
         }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
+        }
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Failure)
 
         // Assert
@@ -564,9 +567,12 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                 },
             )
         }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
+        }
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Retry)
 
         // Assert
@@ -576,6 +582,9 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", -1)
                 },
             )
+        }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
         }
     }
 
@@ -600,7 +609,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `CartItemDevicePaySelected sends event with sale price and platform signal`() = runTest {
+    fun `CartItemDevicePaySelected sends event with object data platform signal`() = runTest {
         // Arrange
         val transactionData = TransactionData(
             paymentType = "GooglePay",
@@ -636,12 +645,14 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         verify(timeout = 2000) {
             platformEvent.invoke(
                 withArg { events ->
-                    assertThat(events).anyMatch {
-                        it.eventType == EventType.SignalCartItemInstantPurchaseInitiated &&
-                            it.parentGuid == "catalog-instance-guid-1" &&
-                            it.eventData?.get("totalPrice") == "79.99" &&
-                            it.eventData?.get("unitPrice") == "79.99"
+                    val platformEvent = events.single {
+                        it.eventType == EventType.SignalCartItemInstantPurchaseInitiated
                     }
+                    assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                    assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
+                    assertThat(platformEvent.objectData).containsEntry("catalogItemId", "catalog-item-1")
+                    assertThat(platformEvent.objectData).containsEntry("quantity", "1")
+                    assertThat(platformEvent.eventData).isNull()
                 },
             )
         }
@@ -663,7 +674,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         val event = captureDevicePayEvent()
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Success)
 
         // Assert
@@ -674,9 +685,16 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                 },
             )
         }
+        verify(exactly = 1, timeout = 2000) {
+            platformEvent.invoke(
+                match { events ->
+                    events.containsSingleDevicePayTerminalEvent(EventType.SignalCartItemInstantPurchase)
+                },
+            )
+        }
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Failure)
 
         // Assert
@@ -687,9 +705,12 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                 },
             )
         }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
+        }
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.Retry)
 
         // Assert
@@ -697,6 +718,67 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
             viewStateChange.invoke(
                 withArg { state ->
                     assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", -1)
+                },
+            )
+        }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
+        }
+    }
+
+    @Test
+    fun `CartItemDevicePay failure callback sends failure platform signal once`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, platformEvent, viewStateChange)
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemDevicePaySelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                paymentProvider = PaymentProvider.GooglePay,
+                transactionData = null,
+                validatorFieldKeys = emptyList(),
+            ),
+        )
+        val event = captureDevicePayEvent()
+
+        // Act
+        clearMocks(platformEvent, viewStateChange)
+        event.onResult(DevicePayResult.Failure)
+
+        // Assert
+        verify(exactly = 1, timeout = 2000) {
+            platformEvent.invoke(
+                match { events ->
+                    events.containsSingleDevicePayTerminalEvent(EventType.SignalCartItemInstantPurchaseFailure)
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `CartItemDevicePay retry callback sends failure platform signal once`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, platformEvent, viewStateChange)
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemDevicePaySelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                paymentProvider = PaymentProvider.GooglePay,
+                transactionData = null,
+                validatorFieldKeys = emptyList(),
+            ),
+        )
+        val event = captureDevicePayEvent()
+
+        // Act
+        clearMocks(platformEvent, viewStateChange)
+        event.onResult(DevicePayResult.Retry)
+
+        // Assert
+        verify(exactly = 1, timeout = 2000) {
+            platformEvent.invoke(
+                match { events ->
+                    events.containsSingleDevicePayTerminalEvent(EventType.SignalCartItemInstantPurchaseFailure)
                 },
             )
         }
@@ -718,8 +800,10 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         val event = captureDevicePayEvent()
 
         // Act
-        clearMocks(viewStateChange)
+        clearMocks(platformEvent, viewStateChange)
         event.onResult(DevicePayResult.PendingConfirmation(mapOf("confirmationRef" to "confirmation-123")))
+        event.onResult(DevicePayResult.Success)
+        event.onResult(DevicePayResult.Failure)
 
         // Assert
         verify(timeout = 2000) {
@@ -728,6 +812,9 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(state.offerCustomStates["0"]).containsEntry("devicePayState", 1)
                 },
             )
+        }
+        verify(exactly = 0, timeout = 500) {
+            platformEvent.invoke(match { events -> events.containsTerminalInstantPurchaseEvent() })
         }
     }
 
@@ -961,6 +1048,20 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         runtimeStateField.isAccessible = true
         return runtimeStateField.get(layoutViewModel) as LayoutRuntimeState
     }
+
+    private fun List<RoktPlatformEvent>.containsTerminalInstantPurchaseEvent(): Boolean = any { it.isTerminalInstantPurchaseEvent() }
+
+    private fun List<RoktPlatformEvent>.containsSingleDevicePayTerminalEvent(eventType: EventType): Boolean {
+        val event = filter { it.isTerminalInstantPurchaseEvent() }.singleOrNull() ?: return false
+        return event.eventType == eventType &&
+            event.parentGuid == "catalog-instance-guid-1" &&
+            event.pageInstanceGuid == "pageInstanceGuid" &&
+            event.eventData == null &&
+            event.objectData == null
+    }
+
+    private fun RoktPlatformEvent.isTerminalInstantPurchaseEvent(): Boolean = eventType == EventType.SignalCartItemInstantPurchase ||
+        eventType == EventType.SignalCartItemInstantPurchaseFailure
 
     private fun createCatalogItemProperties(
         instanceGuid: String = "catalog-instance-guid-1",


### PR DESCRIPTION
## Background

- Android emitted the device-pay initiation signal but did not emit terminal instant purchase platform signals for SDK-managed device-pay outcomes. That left the events API without the success or failure signal expected after the payment extension callback.

## What Has Changed

- Added `SignalCartItemInstantPurchase` and `SignalCartItemInstantPurchaseFailure` platform event types.
- Updated device-pay initiation events to include `pageInstanceGuid` and cart item `objectData` with `catalogItemId` and `quantity`.
- Tracked the pending device-pay catalog item so success emits one terminal purchase signal and failure or retry emits one terminal failure signal.
- Suppressed terminal signals after pending confirmation and left forward-payment terminal results backend-owned.
- Added unit coverage for initiation payloads, terminal success/failure behavior, pending confirmation suppression, and forward-payment callbacks.

## Screenshots/Video

- N/A - no visual changes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Corresponding SDK event mapping was pushed to ROKT/sdk-android-source#1046.
