### PR TITLE
refactor(model): extract SessionToken into its own file in txn package

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -28,9 +28,6 @@ data class SelectResponse(
 )
 
 @Serializable
-data class SessionToken(@SerialName("token") val token: String, @SerialName("expires_at") val expiresAt: Long)
-
-@Serializable
 data class SelectPageContext(
     @SerialName("page_instance_guid") val pageInstanceGuid: String? = null,
     @SerialName("page_id") val pageId: String? = null,

--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SessionToken.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SessionToken.kt
@@ -1,0 +1,8 @@
+package com.rokt.modelmapper.model.txn
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Session token returned on the v2 offers and events responses. */
+@Serializable
+data class SessionToken(@SerialName("token") val token: String, @SerialName("expires_at") val expiresAt: Long)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- `SessionToken` was declared inline inside `SelectResponse.kt` (the v2 offers selection-response model). It is a shared type: both the offers response (`SelectResponse`) and the events response (`EventsResponse`) reference it. Burying it in the offers file made the events models transitively depend on the offers selection-response file and obscured that it's a shared `txn` model.

## What Has Changed

- Moved `SessionToken` out of `SelectResponse.kt` into its own dedicated file `roktux/src/main/java/com/rokt/modelmapper/model/txn/SessionToken.kt`.

## Screenshots/Video

- N/A (model-only refactor)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes


## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])