### PR TITLE
feat: Resolve catalogRuntime placeholders at render time after device pay

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/data/DataBinding.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/data/DataBinding.kt
@@ -93,14 +93,22 @@ private class PlaceholderReplacer(
         return bindData
     }
 
-    private fun replacer(matchResult: MatchResult): String = reducer(removeIdentifiersAndSplit(matchResult.value))
+    private fun replacer(matchResult: MatchResult): String = reducer(
+        keys = removeIdentifiersAndSplit(matchResult.value),
+        rawToken = matchResult.value,
+    )
 
-    private fun reducer(keys: List<String>): String {
+    private fun reducer(keys: List<String>, rawToken: String): String {
         var result: String? = null
         for (key in keys) {
             if (startsWithNamespace.containsMatchIn(key)) {
                 if (isDataTemplate.containsMatchIn(key)) {
                     when (getNamespace(removePrefix(TemplateDataPrefix.DATA, key))) {
+                        CATALOG_RUNTIME_NAMESPACE -> {
+                            // Keep placeholder token for runtime resolution at rendering stage.
+                            result = rawToken
+                        }
+
                         CREATIVE_COPY_NAMESPACE -> {
                             val copyVal = getCreativeCopy(key)
                             if (copyVal != null) {
@@ -256,6 +264,7 @@ private val templatePattern = Regex(
 )
 
 private const val CATALOG_ITEM_IMAGES_PREFIX = "images."
+private const val CATALOG_RUNTIME_NAMESPACE = "catalogRuntime"
 
 private val INDICATOR_POSITION = listOf("IndicatorPosition", "indicatorPosition")
 private val TOTAL_OFFERS = listOf("TotalOffers", "totalOffers")

--- a/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
+++ b/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
@@ -98,19 +98,14 @@ internal fun BindData.getValue(offerState: OfferUiState, viewableItems: Int): St
     else -> null
 }
 
-private fun String.replaceCatalogRuntimePlaceholders(
-    catalogRuntimeData: Map<String, String>,
-): String {
+private fun String.replaceCatalogRuntimePlaceholders(catalogRuntimeData: Map<String, String>): String {
     if (!contains(DATA_CATALOG_RUNTIME_PREFIX)) return this
     return catalogRuntimePlaceholderRegex.replace(this) { match ->
         resolveCatalogRuntimePlaceholder(match.value, catalogRuntimeData)
     }
 }
 
-private fun resolveCatalogRuntimePlaceholder(
-    token: String,
-    catalogRuntimeData: Map<String, String>,
-): String {
+private fun resolveCatalogRuntimePlaceholder(token: String, catalogRuntimeData: Map<String, String>): String {
     val chain = token.removePrefix("%^").removeSuffix("^%")
     if (!chain.contains(DATA_CATALOG_RUNTIME_PREFIX)) return token
     val parts = chain.split('|').map { it.trim() }
@@ -122,6 +117,7 @@ private fun resolveCatalogRuntimePlaceholder(
                     ?.takeIf { it.isNotEmpty() }
                     ?.let { return it }
             }
+
             part.isNotEmpty() || fallback == null -> fallback = part
         }
     }

--- a/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
+++ b/roktux/src/main/java/com/rokt/roktux/utils/Extensions.kt
@@ -89,11 +89,43 @@ internal fun BindData.getValue(offerState: OfferUiState, viewableItems: Int): St
         offerState.currentOfferIndex,
         offerState.lastOfferIndex,
         viewableItems,
+    ).replaceCatalogRuntimePlaceholders(
+        catalogRuntimeData = offerState.catalogRuntimeData,
     )
 
     is BindData.State -> (offerState.currentOfferIndex + 1).toString()
 
     else -> null
+}
+
+private fun String.replaceCatalogRuntimePlaceholders(
+    catalogRuntimeData: Map<String, String>,
+): String {
+    if (!contains(DATA_CATALOG_RUNTIME_PREFIX)) return this
+    return catalogRuntimePlaceholderRegex.replace(this) { match ->
+        resolveCatalogRuntimePlaceholder(match.value, catalogRuntimeData)
+    }
+}
+
+private fun resolveCatalogRuntimePlaceholder(
+    token: String,
+    catalogRuntimeData: Map<String, String>,
+): String {
+    val chain = token.removePrefix("%^").removeSuffix("^%")
+    if (!chain.contains(DATA_CATALOG_RUNTIME_PREFIX)) return token
+    val parts = chain.split('|').map { it.trim() }
+    var fallback: String? = null
+    for (part in parts) {
+        when {
+            part.startsWith(DATA_CATALOG_RUNTIME_PREFIX) -> {
+                catalogRuntimeData[part.removePrefix(DATA_CATALOG_RUNTIME_PREFIX)]
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { return it }
+            }
+            part.isNotEmpty() || fallback == null -> fallback = part
+        }
+    }
+    return fallback ?: token
 }
 
 internal fun Context.getDeviceLocale(): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -426,3 +458,5 @@ private tailrec fun <T> ReceiveChannel<T>.drainAll(
 }
 
 private const val COMPONENT_VISIBILITY_THRESHOLD_RATIO = 0.5f
+private const val DATA_CATALOG_RUNTIME_PREFIX = "DATA.catalogRuntime."
+private val catalogRuntimePlaceholderRegex = Regex("%\\^([a-zA-Z0-9 .|_$\\-]*)\\^%")

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutUiState.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutUiState.kt
@@ -21,6 +21,7 @@ internal data class OfferUiState(
     val creativeCopy: ImmutableMap<String, String>,
     val breakpoints: ImmutableMap<String, Int>,
     val customState: ImmutableMap<String, Int>,
+    val catalogRuntimeData: ImmutableMap<String, String> = emptyMap<String, String>().toImmutableMap(),
     val domainStates: ImmutableMap<String, Int> = emptyMap<String, Int>().toImmutableMap(),
     val offerCustomStates: ImmutableMap<String, ImmutableMap<String, Int>> =
         emptyMap<String, ImmutableMap<String, Int>>().toImmutableMap(),

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -181,6 +181,7 @@ internal class LayoutViewModel(
                         creativeCopy = persistentMapOf(),
                         breakpoints = pluginModel.breakpoint,
                         customState = runtimeState.globalCustomStates().toImmutableMap(),
+                        catalogRuntimeData = runtimeState.catalogRuntimeData().toImmutableMap(),
                         domainStates = runtimeState.domainStates().toImmutableMap(),
                         offerCustomStates = runtimeState.immutableOfferCustomStates(),
                     ),
@@ -539,7 +540,15 @@ internal class LayoutViewModel(
 
             is DevicePayResult.PendingConfirmation -> {
                 runtimeState.setCatalogRuntimeData(result.catalogRuntimeData)
-                updateOfferCustomState(offerId, DEVICE_PAY_STATE_CUSTOM_STATE_KEY, 1)
+                runtimeState.setOfferCustomState(offerId, DEVICE_PAY_STATE_CUSTOM_STATE_KEY, 1)
+                updateState { currentUiState ->
+                    currentUiState.copy(
+                        offerUiState = currentUiState.offerUiState.copy(
+                            offerCustomStates = runtimeState.immutableOfferCustomStates(),
+                            catalogRuntimeData = runtimeState.catalogRuntimeData().toImmutableMap(),
+                        ),
+                    )
+                }
                 pendingDevicePayCatalogItem = null
             }
         }

--- a/roktux/src/test/java/com/rokt/modelmapper/data/DataBindingTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/data/DataBindingTest.kt
@@ -606,6 +606,13 @@ class DataBindingImplTest : MockkUnitTest() {
             0,
         ),
         arrayOf(
+            "%^DATA.catalogRuntime.total|default-total^%",
+            "%^DATA.catalogRuntime.total|default-total^%",
+            null,
+            BindData.Value::class.java,
+            0,
+        ),
+        arrayOf(
             "%^DATA.creativeImage.creativeCarouselImageHorizontal.1.title^%",
             "creativeImage 1 !!!",
             null,

--- a/roktux/src/test/java/com/rokt/roktux/utils/BindDataPlaceholderResolutionTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/utils/BindDataPlaceholderResolutionTest.kt
@@ -1,0 +1,80 @@
+package com.rokt.roktux.utils
+
+import com.rokt.modelmapper.data.BindData
+import com.rokt.roktux.viewmodel.layout.OfferUiState
+import kotlinx.collections.immutable.toImmutableMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BindDataPlaceholderResolutionTest {
+    @Test
+    fun `catalogRuntime placeholders resolve from offer state`() {
+        val value = BindData.Value("Total %^DATA.catalogRuntime.total | --^%").getValue(
+            offerState = offerState(catalogRuntimeData = mapOf("total" to "$107.77")),
+            viewableItems = 1,
+        )
+
+        assertEquals("Total $107.77", value)
+    }
+
+    @Test
+    fun `catalogRuntime placeholders fall back to default literal when data is missing`() {
+        val value = BindData.Value("%^DATA.catalogRuntime.tax | --^%").getValue(
+            offerState = offerState(),
+            viewableItems = 1,
+        )
+
+        assertEquals("--", value)
+    }
+
+    @Test
+    fun `catalogRuntime placeholders resolve repeated tokens consistently`() {
+        val value = BindData.Value(
+            "%^DATA.catalogRuntime.x^%/%^DATA.catalogRuntime.x^%/%^DATA.catalogRuntime.x^%",
+        ).getValue(
+            offerState = offerState(catalogRuntimeData = mapOf("x" to "1")),
+            viewableItems = 1,
+        )
+
+        assertEquals("1/1/1", value)
+    }
+
+    @Test
+    fun `catalogRuntime resolution leaves non catalogRuntime placeholders untouched`() {
+        val value = BindData.Value("Hi %^DATA.creativeCopy.name | friend^%").getValue(
+            offerState = offerState(catalogRuntimeData = mapOf("name" to "ignored")),
+            viewableItems = 1,
+        )
+
+        assertEquals("Hi %^DATA.creativeCopy.name | friend^%", value)
+    }
+
+    @Test
+    fun `catalogRuntime resolution preserves token when no runtime value or fallback`() {
+        val token = "%^DATA.catalogRuntime.x^%"
+        val value = BindData.Value(token).getValue(
+            offerState = offerState(),
+            viewableItems = 1,
+        )
+
+        assertEquals(token, value)
+    }
+
+    @Test
+    fun `getValue returns null for undefined bind data`() {
+        assertNull(BindData.Undefined.getValue(offerState(), viewableItems = 1))
+    }
+
+    private fun offerState(
+        catalogRuntimeData: Map<String, String> = emptyMap(),
+    ): OfferUiState = OfferUiState(
+        currentOfferIndex = 0,
+        lastOfferIndex = 0,
+        viewableItems = 1,
+        creativeCopy = emptyMap<String, String>().toImmutableMap(),
+        breakpoints = emptyMap<String, Int>().toImmutableMap(),
+        customState = emptyMap<String, Int>().toImmutableMap(),
+        catalogRuntimeData = catalogRuntimeData.toImmutableMap(),
+    )
+}


### PR DESCRIPTION
## Background

After device pay returns pending confirmation, the layout needs to show cart totals from host-pushed runtime data. `DATA.catalogRuntime.*` placeholders must stay unresolved during layout mapping and be filled when that runtime data arrives.

## What Has Changed

- Defer `DATA.catalogRuntime.*` tokens in `DataBinding` instead of resolving them at transform time
- Resolve catalog runtime placeholders reactively in `BindData.getValue()` from `OfferUiState.catalogRuntimeData`
- Push `catalogRuntimeData` into UI state after `PendingConfirmation` so text components recompose with updated totals
- Add mapper test coverage for deferred catalog runtime placeholders

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Aligns Android behavior with the iOS reactive catalog runtime placeholder flow.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A