### PR TITLE
feat(bottom-sheet): support expanded percentage-height sheets

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/BottomSheetComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/BottomSheetComponent.kt
@@ -21,10 +21,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
+import com.rokt.modelmapper.uimodel.HeightUiModel
 import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
+import com.rokt.modelmapper.uimodel.ModifierProperties
+import com.rokt.modelmapper.uimodel.StateBlock
 import com.rokt.roktux.utils.interceptTap
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
 internal class BottomSheetComponent(
@@ -63,6 +68,9 @@ internal class BottomSheetComponent(
             model.child.ownModifiers?.getOrNull(breakpointIndex)?.default?.let {
                 modifierFactory.createBackgroundShape(it)
             } ?: RectangleShape
+        val bottomSheetChild = remember(model.child, offerState, breakpointIndex) {
+            model.child.expandPercentageHeightIfNeeded(offerState, breakpointIndex)
+        }
         var hasUserInteracted by remember { mutableStateOf(false) }
         val sheetProperties = remember { BottomSheetPropertiesCompat.create() }
         ModalBottomSheet(
@@ -98,7 +106,7 @@ internal class BottomSheetComponent(
                 }
             }
             factory.CreateComposable(
-                model = model.child,
+                model = bottomSheetChild,
                 modifier = Modifier
                     .animateContentSize()
                     .pointerInput(Unit) {
@@ -117,5 +125,45 @@ internal class BottomSheetComponent(
                 }
             }
         }
+    }
+
+    private fun LayoutSchemaUiModel.ColumnUiModel.expandPercentageHeightIfNeeded(
+        offerState: OfferUiState,
+        breakpointIndex: Int,
+    ): LayoutSchemaUiModel.ColumnUiModel {
+        if (!offerState.isBottomSheetExpanded()) {
+            return this
+        }
+        val breakpointModifier = ownModifiers?.getOrNull(breakpointIndex) ?: return this
+        if (breakpointModifier.default.height !is HeightUiModel.Percentage) {
+            return this
+        }
+        return copy(
+            ownModifiers = ownModifiers.replaceAt(
+                index = breakpointIndex,
+                value = breakpointModifier.copy(
+                    default = breakpointModifier.default.copy(height = HeightUiModel.MatchParent),
+                ),
+            ),
+        )
+    }
+
+    private fun OfferUiState.isBottomSheetExpanded(): Boolean = (
+        offerCustomStates[currentOfferIndex.toString()]?.get(BottomSheetExpandedStateKey)
+            ?: customState[BottomSheetExpandedStateKey]
+            ?: DefaultCustomStateValue
+        ) == ExpandedCustomStateValue
+
+    private fun ImmutableList<StateBlock<ModifierProperties>>.replaceAt(
+        index: Int,
+        value: StateBlock<ModifierProperties>,
+    ): ImmutableList<StateBlock<ModifierProperties>> = mapIndexed { currentIndex, currentValue ->
+        if (currentIndex == index) value else currentValue
+    }.toImmutableList()
+
+    private companion object {
+        const val BottomSheetExpandedStateKey = "BottomSheetExpandedState"
+        const val DefaultCustomStateValue = 0
+        const val ExpandedCustomStateValue = 1
     }
 }

--- a/roktux/src/test/assets/BottomSheetComponent/BottomSheet_with_expandable_percentage_height.json
+++ b/roktux/src/test/assets/BottomSheetComponent/BottomSheet_with_expandable_percentage_height.json
@@ -1,0 +1,89 @@
+{
+  "type": "BottomSheet",
+  "node": {
+    "allowBackdropToClose": true,
+    "styles": {
+      "elements": {
+        "own": [
+          {
+            "default": {
+              "background": {
+                "backgroundColor": {
+                  "light": "#ffffff",
+                  "dark": "#ffffff"
+                }
+              },
+              "dimension": {
+                "height": {
+                  "type": "percentage",
+                  "value": 50
+                }
+              },
+              "spacing": {
+                "padding": "16 16 16 16",
+                "margin": "0 0 0 0"
+              }
+            }
+          }
+        ],
+        "wrapper": [
+          {
+            "default": {
+              "background": {
+                "backgroundColor": {
+                  "light": "#520E0A13",
+                  "dark": "#520E0A13"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "children": [
+      {
+        "type": "BasicText",
+        "node": {
+          "value": "Collapsed content"
+        }
+      },
+      {
+        "type": "ToggleButtonStateTrigger",
+        "node": {
+          "customStateKey": "BottomSheetExpandedState",
+          "children": [
+            {
+              "type": "BasicText",
+              "node": {
+                "value": "Toggle details"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "When",
+        "node": {
+          "predicates": [
+            {
+              "type": "CustomState",
+              "predicate": {
+                "key": "BottomSheetExpandedState",
+                "value": 1,
+                "condition": "is"
+              }
+            }
+          ],
+          "children": [
+            {
+              "type": "BasicText",
+              "node": {
+                "value": "Expanded content"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/roktux/src/test/java/com/rokt/roktux/component/BottomSheetComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/BottomSheetComponentTest.kt
@@ -2,13 +2,21 @@ package com.rokt.roktux.component
 
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
 import com.rokt.core.testutils.annotations.DcuiNodeJson
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
+import com.rokt.roktux.testutil.renderParsedModelWithMutableOfferState
+import com.rokt.roktux.viewmodel.layout.LayoutContract
+import kotlinx.collections.immutable.persistentMapOf
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -21,5 +29,89 @@ class BottomSheetComponentTest : BaseDcuiEspressoTest() {
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertIsDisplayed()
         composeTestRule.onNodeWithText("Purchase successful").assertIsDisplayed()
         composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).assertHeightIsEqualTo(20.dp)
+    }
+
+    @Test
+    @DcuiNodeJson(
+        jsonFile = "BottomSheetComponent/BottomSheet_with_expandable_percentage_height.json",
+        loadComponent = false,
+    )
+    fun testBottomSheetPercentageHeightExpandsAndCollapsesWithCustomState() {
+        val controller = renderParsedModelWithMutableOfferState()
+
+        composeTestRule.onNodeWithText("Collapsed content", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Expanded content", useUnmergedTree = true).assertDoesNotExist()
+        val collapsedHeight = sheetHeight()
+
+        composeTestRule.runOnIdle {
+            controller.setCustomState(BottomSheetExpandedStateKey, 1)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Expanded content", useUnmergedTree = true).assertIsDisplayed()
+        val expandedHeight = sheetHeight()
+        assertTrue(
+            "Expected expanded sheet height ($expandedHeight) to be greater than collapsed height ($collapsedHeight)",
+            expandedHeight > collapsedHeight * ExpandedHeightGrowthThreshold,
+        )
+
+        composeTestRule.runOnIdle {
+            controller.setCustomState(BottomSheetExpandedStateKey, 0)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Expanded content", useUnmergedTree = true).assertDoesNotExist()
+        val collapsedAgainHeight = sheetHeight()
+        assertTrue(
+            "Expected collapsed sheet height ($collapsedAgainHeight) to be less than expanded height ($expandedHeight)",
+            collapsedAgainHeight < expandedHeight / ExpandedHeightGrowthThreshold,
+        )
+    }
+
+    @Test
+    @DcuiNodeJson(
+        jsonFile = "BottomSheetComponent/BottomSheet_with_expandable_percentage_height.json",
+        loadComponent = false,
+    )
+    fun testBottomSheetExpandedStateUsesOfferScopedStateBeforeGlobalState() {
+        renderParsedModelWithMutableOfferState(
+            initialCustomState = persistentMapOf(BottomSheetExpandedStateKey to 1),
+            initialOfferCustomStates = persistentMapOf(
+                "0" to persistentMapOf(BottomSheetExpandedStateKey to 0),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("Collapsed content", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Expanded content", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    @DcuiNodeJson(
+        jsonFile = "BottomSheetComponent/BottomSheet_with_expandable_percentage_height.json",
+        loadComponent = false,
+    )
+    fun testBottomSheetExpandedStateToggleEmitsCustomStateEvent() {
+        renderParsedModelWithMutableOfferState()
+
+        composeTestRule.onNode(
+            hasClickAction() and hasAnyDescendant(hasText("Toggle details")),
+            useUnmergedTree = true,
+        ).performClick()
+
+        assertTrue(
+            getCapturedEvents().any {
+                it == LayoutContract.LayoutEvent.SetCustomState(BottomSheetExpandedStateKey, 1)
+            },
+        )
+    }
+
+    private fun sheetHeight(): Float {
+        composeTestRule.waitForIdle()
+        return composeTestRule.onNodeWithTag(DCUI_COMPONENT_TAG).fetchSemanticsNode().boundsInRoot.height
+    }
+
+    private companion object {
+        const val BottomSheetExpandedStateKey = "BottomSheetExpandedState"
+        const val ExpandedHeightGrowthThreshold = 1.5f
     }
 }

--- a/roktux/src/test/java/com/rokt/roktux/testutil/MutableOfferStateRenderer.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/MutableOfferStateRenderer.kt
@@ -1,6 +1,7 @@
 package com.rokt.roktux.testutil
 
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -23,17 +24,38 @@ import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.Dispatchers
+
+internal class MutableOfferStateController {
+    private var updateCustomState: ((String, Int) -> Unit)? = null
+
+    fun setCustomState(key: String, value: Int) {
+        updateCustomState?.invoke(key, value) ?: error("Mutable offer state renderer is not ready")
+    }
+
+    internal fun bind(updateCustomState: (String, Int) -> Unit) {
+        this.updateCustomState = updateCustomState
+    }
+}
 
 internal fun BaseDcuiEspressoTest.renderParsedModelWithMutableOfferState(
     initialCustomState: PersistentMap<String, Int> = persistentMapOf(),
+    initialOfferCustomStates: PersistentMap<String, PersistentMap<String, Int>> = persistentMapOf(),
     initialActiveCatalogItemIndex: Int = 0,
     testTag: String = DCUI_COMPONENT_TAG,
-) {
+): MutableOfferStateController {
+    val controller = MutableOfferStateController()
     val factory = LayoutUiModelFactory()
     composeTestRule.setContent {
         var customState by remember { mutableStateOf(initialCustomState) }
+        var offerCustomStates by remember { mutableStateOf(initialOfferCustomStates) }
         var activeCatalogItemIndex by remember { mutableIntStateOf(initialActiveCatalogItemIndex) }
+        SideEffect {
+            controller.bind { key, value ->
+                customState = customState.put(key, value)
+            }
+        }
 
         CompositionLocalProvider(
             LocalLayoutComponent provides LayoutComponent(
@@ -69,6 +91,7 @@ internal fun BaseDcuiEspressoTest.renderParsedModelWithMutableOfferState(
                     creativeCopy = persistentMapOf(),
                     breakpoints = persistentMapOf("default" to 0),
                     customState = customState,
+                    offerCustomStates = offerCustomStates,
                     activeCatalogItemIndex = activeCatalogItemIndex,
                 ),
                 isDarkModeEnabled = false,
@@ -80,6 +103,13 @@ internal fun BaseDcuiEspressoTest.renderParsedModelWithMutableOfferState(
                         customState = customState.put(event.key, event.value)
                     }
 
+                    is LayoutContract.LayoutEvent.SetOfferCustomState -> {
+                        offerCustomStates = offerCustomStates.put(
+                            event.offerId.toString(),
+                            event.customState.toPersistentMap(),
+                        )
+                    }
+
                     is LayoutContract.LayoutEvent.SetActiveCatalogItem -> {
                         activeCatalogItemIndex = event.index
                     }
@@ -89,4 +119,5 @@ internal fun BaseDcuiEspressoTest.renderParsedModelWithMutableOfferState(
             }
         }
     }
+    return controller
 }


### PR DESCRIPTION
## Background

- Shoppable ads need the Android bottom sheet to match iOS behavior for dynamic expanded height. Percentage-height bottom sheets should open at their configured height and expand to full available height when the existing `BottomSheetExpandedState` custom state is set to `1`.

## What Has Changed

- Added bottom sheet logic that resolves `BottomSheetExpandedState` from offer-scoped custom state before global state.
- Expands percentage-height bottom sheet children to `MatchParent` only while the resolved state is `1`, leaving fixed, wrap-content, and match-parent layouts unchanged.
- Added an expandable percentage-height bottom sheet fixture with toggle-driven custom state and expanded-only content.
- Added component tests for expand/collapse, offer-scoped state precedence, toggle event emission, and retained fixed-height rendering.
- Extended the mutable offer state test renderer to update global and offer-scoped custom states during composition.

## Screenshots/Video

- This changes bottom sheet UI behavior. Please add a screenshot or video showing the collapsed and expanded states before merge.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified locally with `./gradlew :roktux:testReleaseUnitTest --tests "com.rokt.roktux.component.BottomSheetComponentTest"`, `./gradlew test`, `./gradlew lint`, and `trunk check --ci`.
- No Roborazzi baseline was added because new snapshot baselines are generated from CI artifacts per `roktux/src/test/README.md`.