### PR TITLE
feat(layout): accept parsed experience responses

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
@@ -62,8 +62,13 @@ interface ModelMapper {
     fun getSavedExperience(): ExperienceModel?
 }
 
-class ExperienceModelMapperImpl(private val experienceResponse: String, private val dataBinding: DataBinding) :
-    ModelMapper {
+class ExperienceModelMapperImpl(
+    private val experienceResponse: String?,
+    private val parsedExperienceResponse: NetworkExperienceResponse?,
+    private val dataBinding: DataBinding,
+) : ModelMapper {
+
+    constructor(experienceResponse: String, dataBinding: DataBinding) : this(experienceResponse, null, dataBinding)
 
     var savedExperienceModel: Result<ExperienceModel>? = null
 
@@ -76,8 +81,10 @@ class ExperienceModelMapperImpl(private val experienceResponse: String, private 
     override fun transformResponse(): Result<ExperienceModel> {
         RoktUXLogger.verbose { "Transforming experience response" }
         savedExperienceModel = try {
-            json.decodeFromString<NetworkExperienceResponse>(experienceResponse)
-                .let { Result.success(it.toExperienceModel()) }
+            val networkResponse = parsedExperienceResponse ?: json.decodeFromString(
+                requireNotNull(experienceResponse) { "Experience response is required" },
+            )
+            Result.success(networkResponse.toExperienceModel())
         } catch (e: Throwable) {
             RoktUXLogger.error(error = e) { "Failed to transform experience response" }
             Result.failure(e)

--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rokt.core.composablescoped.WithComposableScopedViewModelStoreOwner
+import com.rokt.modelmapper.model.NetworkExperienceResponse
 import com.rokt.modelmapper.utils.FIRST_OFFER_INDEX
 import com.rokt.modelmapper.utils.ROKT_ICONS_FONT_FAMILY
 import com.rokt.roktux.component.LayoutUiModelFactory
@@ -80,6 +81,45 @@ fun RoktLayout(
     }
     RoktLayout(
         experienceResponse = experienceResponse,
+        parsedExperienceResponse = null,
+        location = location,
+        roktUxConfig = roktUxConfig,
+        mainDispatcher = Dispatchers.Main,
+        ioDispatcher = Dispatchers.IO,
+        modifier = modifier,
+        startTimeStamp = startTimeStamp,
+        onUxEvent = onUxEvent,
+        onPlatformEvent = onPlatformEvent,
+    )
+}
+
+/**
+ * Composable function to render the Rokt layout from a pre-parsed experience response.
+ *
+ * @param experienceResponse The parsed experience response.
+ * @param location The location identifier for the layout.
+ * @param modifier The modifier to be applied to the layout.
+ * @param roktUxConfig The configuration for the Rokt UX.
+ * @param startTimeStamp Optional - The start timestamp of the layout request.
+ * @param onUxEvent Callback for UX events.
+ * @param onPlatformEvent Callback for platform events.
+ */
+@Composable
+fun RoktLayout(
+    experienceResponse: NetworkExperienceResponse,
+    location: String,
+    modifier: Modifier = Modifier,
+    roktUxConfig: RoktUxConfig,
+    startTimeStamp: Long = System.currentTimeMillis(),
+    onUxEvent: (event: RoktUxEvent) -> Unit = { },
+    onPlatformEvent: (platformEvents: RoktPlatformEventsWrapper) -> Unit = { },
+) {
+    LaunchedEffect(location) {
+        RoktUXLogger.verbose { "RoktLayout loading for location: $location" }
+    }
+    RoktLayout(
+        experienceResponse = null,
+        parsedExperienceResponse = experienceResponse,
         location = location,
         roktUxConfig = roktUxConfig,
         mainDispatcher = Dispatchers.Main,
@@ -93,7 +133,8 @@ fun RoktLayout(
 
 @Composable
 internal fun RoktLayout(
-    experienceResponse: String,
+    experienceResponse: String?,
+    parsedExperienceResponse: NetworkExperienceResponse? = null,
     location: String,
     roktUxConfig: RoktUxConfig,
     mainDispatcher: CoroutineDispatcher,
@@ -103,7 +144,8 @@ internal fun RoktLayout(
     onUxEvent: (event: RoktUxEvent) -> Unit = { },
     onPlatformEvent: (platformEvents: RoktPlatformEventsWrapper) -> Unit = { },
 ) {
-    val experienceHash = experienceResponse.hashCode().toString()
+    val experienceHash = parsedExperienceResponse?.stableExperienceKey()
+        ?: experienceResponse.orEmpty().hashCode().toString()
     val context = LocalContext.current
     val imageLoader = roktUxConfig.imageHandlingStrategy.getImageLoader(context)
     var currentOffer by rememberSaveable(key = experienceHash) {
@@ -146,6 +188,7 @@ internal fun RoktLayout(
             val viewModel = viewModel<DIComponentViewModel>(
                 factory = DIComponentViewModel.DIComponentViewModelFactory(
                     experienceResponse = experienceResponse,
+                    parsedExperienceResponse = parsedExperienceResponse,
                     location = location,
                     uxEvent = onUxEvent,
                     startTimeStamp = startTimeStamp,
@@ -190,6 +233,9 @@ internal fun RoktLayout(
         onUxEvent(RoktUxEvent.LayoutCompleted(roktUxConfig.viewStateConfig?.viewState?.pluginId ?: ""))
     }
 }
+
+private fun NetworkExperienceResponse.stableExperienceKey(): String =
+    plugins.firstOrNull()?.plugin?.config?.instanceGuid ?: "$sessionId:${pageContext.pageInstanceGuid}"
 
 @SuppressLint("ComposeViewModelInjection")
 @Composable

--- a/roktux/src/main/java/com/rokt/roktux/RoktLayoutView.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayoutView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import com.rokt.modelmapper.model.NetworkExperienceResponse
 import com.rokt.roktux.event.RoktPlatformEventsWrapper
 import com.rokt.roktux.event.RoktUxEvent
 import kotlinx.collections.immutable.ImmutableList
@@ -36,7 +37,8 @@ class RoktLayoutView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyle) {
 
     // Mutable state to hold the experience response.
-    private var experienceResponse by mutableStateOf("")
+    private var experienceResponse by mutableStateOf<String?>(null)
+    private var parsedExperienceResponse by mutableStateOf<NetworkExperienceResponse?>(null)
 
     // Event handlers for UX and platform events.
     private var uxEvent: ((event: RoktUxEvent) -> Unit) = {}
@@ -61,7 +63,7 @@ class RoktLayoutView @JvmOverloads constructor(
      */
     @Composable
     override fun Content() {
-        if (experienceResponse.isNotEmpty()) {
+        if (experienceResponse?.isNotEmpty() == true || parsedExperienceResponse != null) {
             val roktConfig: RoktUxConfig = remember(roktUxConfig) {
                 val composeFontMap =
                     roktUxConfig?.xmlFontFamilyMap?.mapValues { getFontFamily(it.value.toPersistentList()) }
@@ -74,8 +76,16 @@ class RoktLayoutView @JvmOverloads constructor(
                     roktUxConfig?.edgeToEdgeDisplay?.let { edgeToEdgeDisplay(it) }
                 }.build()
             }
-            RoktLayout(
-                experienceResponse = experienceResponse,
+            parsedExperienceResponse?.let {
+                RoktLayout(
+                    experienceResponse = it,
+                    location = location.orEmpty(),
+                    roktUxConfig = roktConfig,
+                    onUxEvent = uxEvent,
+                    onPlatformEvent = platformEvents,
+                )
+            } ?: RoktLayout(
+                experienceResponse = experienceResponse.orEmpty(),
                 location = location.orEmpty(),
                 roktUxConfig = roktConfig,
                 onUxEvent = uxEvent,
@@ -101,6 +111,28 @@ class RoktLayoutView @JvmOverloads constructor(
         this.uxEvent = onUxEvent
         this.platformEvents = onPlatformEvent
         this.experienceResponse = experienceResponse
+        this.parsedExperienceResponse = null
+        this.roktUxConfig = roktUxConfig
+    }
+
+    /**
+     * Loads the layout with the given parameters.
+     *
+     * @param experienceResponse The parsed experience response.
+     * @param roktUxConfig The Rokt UX configuration.
+     * @param onUxEvent The UX event handler.
+     * @param onPlatformEvent The platform event handler.
+     */
+    fun loadLayout(
+        experienceResponse: NetworkExperienceResponse,
+        roktUxConfig: RoktUxConfig,
+        onUxEvent: ((event: RoktUxEvent) -> Unit),
+        onPlatformEvent: ((platformEvents: RoktPlatformEventsWrapper) -> Unit),
+    ) {
+        this.uxEvent = onUxEvent
+        this.platformEvents = onPlatformEvent
+        this.experienceResponse = null
+        this.parsedExperienceResponse = experienceResponse
         this.roktUxConfig = roktUxConfig
     }
 

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.text.font.FontFamily
 import coil.ImageLoader
 import com.rokt.core.di.Component
+import com.rokt.modelmapper.model.NetworkExperienceResponse
 import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.event.RoktPlatformEvent
 import com.rokt.roktux.event.RoktUxEvent
@@ -11,7 +12,8 @@ import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.coroutines.CoroutineDispatcher
 
 internal class LayoutComponent(
-    experienceResponse: String,
+    experienceResponse: String?,
+    parsedExperienceResponse: NetworkExperienceResponse?,
     location: String,
     startTimeStamp: Long,
     onUxEvent: (event: RoktUxEvent) -> Unit,
@@ -30,6 +32,7 @@ internal class LayoutComponent(
     listOf(
         LayoutModule(
             experienceResponse,
+            parsedExperienceResponse,
             location,
             startTimeStamp,
             onUxEvent,

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
@@ -6,6 +6,7 @@ import com.rokt.modelmapper.data.DataBinding
 import com.rokt.modelmapper.data.DataBindingImpl
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl
 import com.rokt.modelmapper.mappers.ModelMapper
+import com.rokt.modelmapper.model.NetworkExperienceResponse
 import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.component.LayoutUiModelFactory
 import com.rokt.roktux.event.RoktPlatformEvent
@@ -15,7 +16,8 @@ import com.rokt.roktux.viewmodel.layout.LayoutViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 
 internal class LayoutModule(
-    private val experience: String,
+    private val experience: String?,
+    private val parsedExperience: NetworkExperienceResponse?,
     private val location: String,
     private val startTimeStamp: Long,
     private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
@@ -38,8 +40,7 @@ internal class LayoutModule(
         this.provideModuleScoped { DataBindingImpl() }
         this.provideModuleScoped { LayoutUiModelFactory() }
         this.provideModuleScoped { ValidationCoordinator() }
-        this.provideModuleScoped { ExperienceModelMapperImpl(get(EXPERIENCE), get()) }
-        this.provideModuleScoped(EXPERIENCE) { experience }
+        this.provideModuleScoped { ExperienceModelMapperImpl(experience, parsedExperience, get()) }
         this.provideModuleScoped(LOCATION) { location }
         this.provideModuleScoped<CoroutineDispatcher>(IO) { ioDispatcher }
         this.provideModuleScoped<CoroutineDispatcher>(MAIN) { mainDispatcher }
@@ -68,7 +69,6 @@ internal class LayoutModule(
     }
 
     companion object {
-        const val EXPERIENCE = "EXPERIENCE"
         const val LOCATION = "Location"
         const val IO = "IO"
         const val MAIN = "MAIN"

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import coil.ImageLoader
+import com.rokt.modelmapper.model.NetworkExperienceResponse
 import com.rokt.roktux.RoktViewState
 import com.rokt.roktux.di.layout.LayoutComponent
 import com.rokt.roktux.event.RoktPlatformEvent
@@ -11,7 +12,8 @@ import com.rokt.roktux.event.RoktUxEvent
 import kotlinx.coroutines.CoroutineDispatcher
 
 internal class DIComponentViewModel(
-    private val experienceResponse: String,
+    private val experienceResponse: String?,
+    private val parsedExperienceResponse: NetworkExperienceResponse?,
     private val location: String,
     private val startTimeStamp: Long,
     private val onUxEvent: (uxEvent: RoktUxEvent) -> Unit,
@@ -30,6 +32,7 @@ internal class DIComponentViewModel(
 
     val component = LayoutComponent(
         experienceResponse,
+        parsedExperienceResponse,
         location,
         startTimeStamp,
         onUxEvent,
@@ -47,7 +50,8 @@ internal class DIComponentViewModel(
     )
 
     class DIComponentViewModelFactory(
-        private val experienceResponse: String,
+        private val experienceResponse: String?,
+        private val parsedExperienceResponse: NetworkExperienceResponse?,
         private val location: String,
         private val startTimeStamp: Long,
         private val uxEvent: (uxEvent: RoktUxEvent) -> Unit,
@@ -68,6 +72,7 @@ internal class DIComponentViewModel(
             if (modelClass.isAssignableFrom(DIComponentViewModel::class.java)) {
                 return DIComponentViewModel(
                     experienceResponse = experienceResponse,
+                    parsedExperienceResponse = parsedExperienceResponse,
                     location = location,
                     startTimeStamp = startTimeStamp,
                     onUxEvent = uxEvent,

--- a/roktux/src/test/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImplTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImplTest.kt
@@ -1,0 +1,53 @@
+package com.rokt.modelmapper.mappers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rokt.core.testutils.TestJsonLoader
+import com.rokt.modelmapper.data.DataBindingImpl
+import com.rokt.modelmapper.model.NetworkExperienceResponse
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExperienceModelMapperImplTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `transformResponse should return same model for string and parsed responses`() {
+        // Arrange
+        val experienceResponse = TestJsonLoader.loadJsonFromAssetsDirectory("Snapshot", "EmbeddedCompact.json")
+        val parsedExperienceResponse = json.decodeFromString<NetworkExperienceResponse>(experienceResponse)
+
+        // Act
+        val stringResult = ExperienceModelMapperImpl(experienceResponse, DataBindingImpl()).transformResponse()
+        val parsedResult = ExperienceModelMapperImpl(null, parsedExperienceResponse, DataBindingImpl()).transformResponse()
+
+        // Assert
+        val stringModel = stringResult.getOrThrow()
+        val parsedModel = parsedResult.getOrThrow()
+        assertTrue(stringModel.sessionId == parsedModel.sessionId)
+        assertTrue(stringModel.token == parsedModel.token)
+        assertTrue(stringModel.pageId == parsedModel.pageId)
+        assertTrue(stringModel.plugins.size == parsedModel.plugins.size)
+        assertTrue(stringModel.plugins.first().id == parsedModel.plugins.first().id)
+        assertTrue(stringModel.plugins.first().slots.size == parsedModel.plugins.first().slots.size)
+    }
+
+    @Test
+    fun `transformResponse should not decode string when parsed response is provided`() {
+        // Arrange
+        val experienceResponse = TestJsonLoader.loadJsonFromAssetsDirectory("Snapshot", "EmbeddedCompact.json")
+        val parsedExperienceResponse = json.decodeFromString<NetworkExperienceResponse>(experienceResponse)
+
+        // Act
+        val result = ExperienceModelMapperImpl("{", parsedExperienceResponse, DataBindingImpl()).transformResponse()
+
+        // Assert
+        assertTrue(result.isSuccess)
+    }
+}

--- a/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/DcuiComponentRule.kt
@@ -64,6 +64,7 @@ class DcuiComponentRule(
         val breakpoints = buildBreakpoints(dcuiNodeComponentState?.breakpoints)
         layoutComponent = LayoutComponent(
             experienceResponse = "",
+            parsedExperienceResponse = null,
             location = "",
             startTimeStamp = System.currentTimeMillis(),
             onUxEvent = {},

--- a/roktux/src/test/java/com/rokt/roktux/testutil/MutableOfferStateRenderer.kt
+++ b/roktux/src/test/java/com/rokt/roktux/testutil/MutableOfferStateRenderer.kt
@@ -60,6 +60,7 @@ internal fun BaseDcuiEspressoTest.renderParsedModelWithMutableOfferState(
         CompositionLocalProvider(
             LocalLayoutComponent provides LayoutComponent(
                 experienceResponse = "",
+                parsedExperienceResponse = null,
                 location = "",
                 startTimeStamp = System.currentTimeMillis(),
                 onUxEvent = {},


### PR DESCRIPTION
## Background

- SDK integrations can already obtain or retain a parsed experience response before handing it to UX Helper. Previously, rendering APIs accepted only raw response JSON, so integrations had to decode the same layout data again before rendering. This change adds parsed-response entry points so rendering can reuse the existing model.

## What Has Changed

- Added `RoktLayout` and `RoktLayoutView.loadLayout` overloads that accept `NetworkExperienceResponse`.
- Passed the parsed response through layout dependency injection and view model setup.
- Updated `ExperienceModelMapperImpl` to transform a provided parsed response directly, while keeping the existing string response path.
- Added mapper tests that compare string and parsed response transformations and confirm invalid JSON is not decoded when a parsed response is present.

## Screenshots/Video

- N/A - no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- N/A - no migration notes or reviewer-specific setup.