### PR TITLE
feat(payment): seed completed device-pay offers into confirmation on init

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktLayout.kt
@@ -169,6 +169,7 @@ internal fun RoktLayout(
                     domainStates = domainStates,
                     handleUrlByApp = roktUxConfig.handleUrlByApp,
                     edgeToEdgeDisplay = roktUxConfig.edgeToEdgeDisplay,
+                    completedDevicePayCartItemIds = roktUxConfig.completedDevicePayCartItemIds,
                     mainDispatcher = mainDispatcher,
                     ioDispatcher = ioDispatcher,
                 ),

--- a/roktux/src/main/java/com/rokt/roktux/RoktUxConfig.kt
+++ b/roktux/src/main/java/com/rokt/roktux/RoktUxConfig.kt
@@ -22,6 +22,7 @@ class RoktUxConfig private constructor(
     val viewStateConfig: ViewStateConfig? = null,
     val handleUrlByApp: Boolean = true,
     val edgeToEdgeDisplay: Boolean = true,
+    val completedDevicePayCartItemIds: Set<String> = emptySet(),
 ) {
     /**
      * Builder class for RoktUxConfig.
@@ -41,6 +42,7 @@ class RoktUxConfig private constructor(
         private var handleUrlByApp: Boolean = true,
         private var viewStateConfig: ViewStateConfig? = null,
         private var edgeToEdgeDisplay: Boolean = true,
+        private var completedDevicePayCartItemIds: Set<String> = emptySet(),
     ) {
         /**
          * Sets the XML font family map.
@@ -93,6 +95,18 @@ class RoktUxConfig private constructor(
         fun edgeToEdgeDisplay(edgeToEdgeDisplay: Boolean) = apply { this.edgeToEdgeDisplay = edgeToEdgeDisplay }
 
         /**
+         * Seeds offers whose device-pay purchase already completed (by cart item id) into their
+         * post-purchase state on first composition. Used to restore the confirmation screen when
+         * the host was destroyed mid-checkout (e.g. Don't-Keep-Activities / low-memory reclaim).
+         *
+         * @param completedDevicePayCartItemIds Cart item ids whose purchase already succeeded.
+         * @return The Builder instance.
+         */
+        fun completedDevicePayCartItemIds(completedDevicePayCartItemIds: Set<String>) = apply {
+            this.completedDevicePayCartItemIds = completedDevicePayCartItemIds
+        }
+
+        /**
          * Builds the RoktUxConfig instance.
          *
          * @return The RoktUxConfig instance.
@@ -105,6 +119,7 @@ class RoktUxConfig private constructor(
             handleUrlByApp = handleUrlByApp,
             viewStateConfig = viewStateConfig,
             edgeToEdgeDisplay = edgeToEdgeDisplay,
+            completedDevicePayCartItemIds = completedDevicePayCartItemIds,
         )
     }
 

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutComponent.kt
@@ -24,6 +24,7 @@ internal class LayoutComponent(
     offerCustomStates: Map<String, Map<String, Int>>,
     domainStates: Map<String, Int>,
     edgeToEdgeDisplay: Boolean,
+    completedDevicePayCartItemIds: Set<String> = emptySet(),
     mainDispatcher: CoroutineDispatcher,
     ioDispatcher: CoroutineDispatcher,
 ) : Component(
@@ -42,6 +43,7 @@ internal class LayoutComponent(
             offerCustomStates,
             domainStates,
             edgeToEdgeDisplay,
+            completedDevicePayCartItemIds,
             mainDispatcher,
             ioDispatcher,
         ),

--- a/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
+++ b/roktux/src/main/java/com/rokt/roktux/di/layout/LayoutModule.kt
@@ -28,6 +28,7 @@ internal class LayoutModule(
     private val offerCustomStates: Map<String, Map<String, Int>>,
     private val domainStates: Map<String, Int>,
     private val edgeToEdgeDisplay: Boolean,
+    private val completedDevicePayCartItemIds: Set<String>,
     private val mainDispatcher: CoroutineDispatcher,
     private val ioDispatcher: CoroutineDispatcher,
 ) : Module() {
@@ -60,6 +61,7 @@ internal class LayoutModule(
                 domainStates = domainStates,
                 validationCoordinator = get(),
                 edgeToEdgeDisplay = edgeToEdgeDisplay,
+                completedDevicePayCartItemIds = completedDevicePayCartItemIds,
             )
         }
         this.provideModuleScoped {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/component/DIComponentViewModel.kt
@@ -24,6 +24,7 @@ internal class DIComponentViewModel(
     private val domainStates: Map<String, Int>,
     private val handleUrlByApp: Boolean,
     private val edgeToEdgeDisplay: Boolean,
+    private val completedDevicePayCartItemIds: Set<String>,
     private val mainDispatcher: CoroutineDispatcher,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -42,6 +43,7 @@ internal class DIComponentViewModel(
         offerCustomStates,
         domainStates,
         edgeToEdgeDisplay,
+        completedDevicePayCartItemIds,
         mainDispatcher,
         ioDispatcher,
     )
@@ -60,6 +62,7 @@ internal class DIComponentViewModel(
         private val domainStates: Map<String, Int>,
         private val handleUrlByApp: Boolean,
         private val edgeToEdgeDisplay: Boolean,
+        private val completedDevicePayCartItemIds: Set<String>,
         private val mainDispatcher: CoroutineDispatcher,
         private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModelProvider.Factory {
@@ -80,6 +83,7 @@ internal class DIComponentViewModel(
                     domainStates = domainStates,
                     handleUrlByApp = handleUrlByApp,
                     edgeToEdgeDisplay = edgeToEdgeDisplay,
+                    completedDevicePayCartItemIds = completedDevicePayCartItemIds,
                     mainDispatcher = mainDispatcher,
                     ioDispatcher = ioDispatcher,
                 ) as T

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -67,6 +67,7 @@ internal class LayoutViewModel(
     domainStates: Map<String, Int>,
     validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
     private var edgeToEdgeDisplay: Boolean,
+    private val completedDevicePayCartItemIds: Set<String> = emptySet(),
 ) : BaseViewModel<LayoutContract.LayoutEvent, LayoutUiState, LayoutContract.LayoutEffect>() {
 
     private lateinit var pluginId: String
@@ -167,6 +168,8 @@ internal class LayoutViewModel(
         }
         val lastOfferIndex = pluginModel.slots.size - 1
         pluginId = pluginModel.id
+
+        seedCompletedDevicePayOffers()
 
         if (layoutSchema != null && lastOfferIndex >= FIRST_OFFER_INDEX) {
             sendViewState(currentOffer)
@@ -932,6 +935,24 @@ internal class LayoutViewModel(
         ?.properties
         ?.instanceGuid()
 
+    /**
+     * Seeds offers whose device-pay purchase already completed into their post-purchase state
+     * (`paymentResult = 1`) before the first layout state is emitted, so the confirmation renders
+     * immediately when the host is recreated mid-checkout. Reuses the same offer custom state the
+     * live [handleCartItemDevicePayResult] success path sets; unmatched cart item ids are ignored.
+     */
+    private fun seedCompletedDevicePayOffers() {
+        if (completedDevicePayCartItemIds.isEmpty()) return
+        completedDevicePayCartItemIds.forEach { cartItemId ->
+            val offerIndex = pluginModel.slots.indexOfFirst { slot ->
+                slot.offer?.catalogItems?.any { it.properties.cartItemId() == cartItemId } == true
+            }
+            if (offerIndex >= FIRST_OFFER_INDEX) {
+                runtimeState.setOfferCustomState(offerIndex, PAYMENT_RESULT_CUSTOM_STATE_KEY, 1)
+            }
+        }
+    }
+
     private fun HMap.originalPrice(): Double = get<Double>(KEY_ORIGINAL_PRICE) ?: 0.0
 
     private fun HMap.salePrice(): Double = get<Double>(KEY_PRICE) ?: originalPrice()
@@ -1008,6 +1029,7 @@ internal class LayoutViewModel(
         private val domainStates: Map<String, Int>,
         private val validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
         private val edgeToEdgeDisplay: Boolean,
+        private val completedDevicePayCartItemIds: Set<String> = emptySet(),
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
@@ -1028,6 +1050,7 @@ internal class LayoutViewModel(
                     domainStates = domainStates,
                     validationCoordinator = validationCoordinator,
                     edgeToEdgeDisplay = edgeToEdgeDisplay,
+                    completedDevicePayCartItemIds = completedDevicePayCartItemIds,
                 ) as T
             }
             throw IllegalArgumentException("Unknown ViewModel type")

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -117,6 +117,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         handleUrlByApp: Boolean = true,
         domainStates: Map<String, Int> = emptyMap(),
         validationCoordinator: ValidationCoordinator = ValidationCoordinator(),
+        completedDevicePayCartItemIds: Set<String> = emptySet(),
     ) {
         layoutViewModel = LayoutViewModel(
             location = "location1",
@@ -134,7 +135,44 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
             domainStates = domainStates,
             validationCoordinator = validationCoordinator,
             edgeToEdgeDisplay = false,
+            completedDevicePayCartItemIds = completedDevicePayCartItemIds,
         )
+    }
+
+    @Test
+    fun `completedDevicePayCartItemIds seeds the matching offer into its post-purchase state on init`() = runTest {
+        // Arrange: a fresh VM seeded with a completed purchase for the cart item in offer index 0,
+        // simulating restore after the host was destroyed mid-checkout (no live device-pay event).
+        clearMocks(viewStateChange)
+        initialize(completedDevicePayCartItemIds = setOf("cart-item-1"))
+
+        // Act
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.LayoutInitialised)
+
+        // Assert: offer 0 is already in its paymentResult=1 (confirmation) state on first render.
+        verify(timeout = 2000) {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.offerCustomStates["0"]).containsEntry("paymentResult", 1)
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `completedDevicePayCartItemIds does not seed any offer when the cart item is unknown`() = runTest {
+        clearMocks(viewStateChange)
+        initialize(completedDevicePayCartItemIds = setOf("not-a-real-cart-item"))
+
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.LayoutInitialised)
+
+        verify(timeout = 2000) {
+            viewStateChange.invoke(
+                withArg { state ->
+                    assertThat(state.offerCustomStates["0"]?.get("paymentResult")).isNull()
+                },
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Background

- On Android, when the host SDK's Activity/ViewModel is destroyed mid-checkout (Don't-Keep-Activities or low-memory reclaim) while the buyer is in the PayPal browser, the device-pay success resolves into a dead callback. The layout is recreated showing the **offer** instead of the confirmation, because the `paymentResult` offer custom state was never set (the live `CartItemForwardPayment` success path never ran).
- The SDK can persist that a purchase completed, but it has no way to tell roktux to render that offer's post-purchase state on init: the public event doesn't expose `offerId` and the `paymentResult` key is internal.

## What Has Changed

- Adds `RoktUxConfig.completedDevicePayCartItemIds: Set<String>` (builder method `completedDevicePayCartItemIds(...)`) — cart item ids whose device-pay purchase already completed.
- On first composition, `LayoutViewModel` resolves each cart item id to its offer (after the experience is parsed, before the first state is emitted) and seeds that offer's `paymentResult = 1` — the **same** offer custom state the live `handleCartItemDevicePayResult(Success)` path sets, reusing the existing `offerCustomStates` restore plumbing.
- No layout state-machine changes; unmatched cart item ids are ignored. The new input is threaded through the existing `RoktUxConfig → RoktLayout → DIComponentViewModel → LayoutComponent → LayoutModule → LayoutViewModel` chain and defaults to empty (fully backward compatible).

## Screenshots/Video

- {N/A — covered by unit tests}

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Consumed by the Rokt Android SDK to restore the PayPal confirmation screen after process/Activity reclaim (paired SDK PR forthcoming). Tests added in `RoktLayoutViewModelTest` (seeds matching offer; ignores unknown cart item id).

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])