### PR TITLE
feat(txn-catalog): give v2 select catalog_items a type

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -28,9 +28,14 @@ data class SelectResponse(
 
 @Serializable
 data class SelectPageContext(
+    @SerialName("rokt_tag_id") val roktTagId: String? = null,
     @SerialName("page_instance_guid") val pageInstanceGuid: String? = null,
     @SerialName("page_id") val pageId: String? = null,
+    @SerialName("page_type") val pageType: String? = null,
     @SerialName("language") val language: String? = null,
+    @SerialName("is_page_detected") val isPageDetected: Boolean? = null,
+    @SerialName("page_variant_name") val pageVariantName: String? = null,
+    @SerialName("partner_content_template") val partnerContentTemplate: String? = null,
     @SerialName("token") val token: String? = null,
 )
 

--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -6,10 +6,18 @@ import com.rokt.network.model.LayoutDisplayPreset
 import com.rokt.network.model.LayoutSchemaModel
 import com.rokt.network.model.LayoutSettings
 import com.rokt.network.model.RootSchemaModel
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Selection response for a v2 offers request — the model the renderer consumes,
@@ -77,8 +85,59 @@ data class SelectLayoutVariant(
 data class SelectOffer(
     @SerialName("campaign_id") val campaignId: String? = null,
     @SerialName("creative") val creative: SelectCreative? = null,
-    @SerialName("catalog_items") val catalogItems: List<JsonObject>? = null,
+    @SerialName("catalog_items") val catalogItems: List<SelectCatalogItem>? = null,
 )
+
+/**
+ * A catalog item from a v2 offers selection response.
+ *
+ * The transactions catalog-item shape is open and campaign-specific — only
+ * [instanceGuid] and [title] are guaranteed; every other field varies by
+ * campaign type. To stay type-safe without risking decode failures as that
+ * shape changes, the guaranteed fields are surfaced as (optional) typed
+ * accessors while the full payload is retained in [raw] so any
+ * campaign-specific field still round-trips. Decoding never fails on an
+ * unrecognised shape.
+ *
+ * When the renderer starts consuming catalog items, promote the fields it needs
+ * from [raw] into typed (optional) properties here.
+ */
+@Serializable(with = SelectCatalogItemSerializer::class)
+data class SelectCatalogItem(
+    /** The complete decoded payload, keyed by the raw (snake_case) JSON key. */
+    val raw: JsonObject,
+) {
+    /** Guaranteed by the server contract for every catalog item. */
+    val instanceGuid: String?
+        get() = raw["instance_guid"]?.jsonPrimitive?.contentOrNull
+
+    /** Guaranteed by the server contract for every catalog item. */
+    val title: String?
+        get() = raw["title"]?.jsonPrimitive?.contentOrNull
+}
+
+/**
+ * Captures the whole catalog-item object into [SelectCatalogItem.raw] so unknown
+ * / campaign-specific fields are preserved, rather than mapping a fixed field
+ * set. Keeps [raw] as the single source of truth for the wire shape.
+ */
+internal object SelectCatalogItemSerializer : KSerializer<SelectCatalogItem> {
+    private val delegate = JsonObject.serializer()
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun deserialize(decoder: Decoder): SelectCatalogItem {
+        val input = decoder as? JsonDecoder
+            ?: error("SelectCatalogItem can only be deserialized from JSON")
+        return SelectCatalogItem(raw = delegate.deserialize(input))
+    }
+
+    override fun serialize(encoder: Encoder, value: SelectCatalogItem) {
+        val output = encoder as? JsonEncoder
+            ?: error("SelectCatalogItem can only be serialized to JSON")
+        delegate.serialize(output, value.raw)
+    }
+}
 
 @Serializable
 data class SelectCreative(

--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -9,6 +9,7 @@ import com.rokt.network.model.RootSchemaModel
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -16,8 +17,7 @@ import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Selection response for a v2 offers request — the model the renderer consumes,
@@ -81,12 +81,54 @@ data class SelectLayoutVariant(
     val layoutVariantSchema: LayoutSchemaModel? = null,
 )
 
-@Serializable
+@Serializable(with = SelectOfferSerializer::class)
 data class SelectOffer(
-    @SerialName("campaign_id") val campaignId: String? = null,
-    @SerialName("creative") val creative: SelectCreative? = null,
-    @SerialName("catalog_items") val catalogItems: List<SelectCatalogItem>? = null,
+    val campaignId: String? = null,
+    val creative: SelectCreative? = null,
+    val catalogItems: List<SelectCatalogItem>? = null,
 )
+
+/**
+ * Decodes `catalog_items` as opaque [JsonElement]s first so a non-object element
+ * (a bare string, number, null, nested array, etc.) does not fail the whole
+ * response decode — consistent with the "never fail on shape drift" promise. Only
+ * the object-shaped elements become typed [SelectCatalogItem]s; anything else is
+ * skipped. An absent key stays `null`; an empty array stays an empty (non-null)
+ * list. Mirrors the iOS `SelectOffer.init(from:)` resilient skip.
+ */
+internal object SelectOfferSerializer : KSerializer<SelectOffer> {
+    @Serializable
+    private data class Surrogate(
+        @SerialName("campaign_id") val campaignId: String? = null,
+        @SerialName("creative") val creative: SelectCreative? = null,
+        @SerialName("catalog_items") val catalogItems: List<JsonElement>? = null,
+    )
+
+    override val descriptor: SerialDescriptor = Surrogate.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): SelectOffer {
+        val surrogate = Surrogate.serializer().deserialize(decoder)
+        return SelectOffer(
+            campaignId = surrogate.campaignId,
+            creative = surrogate.creative,
+            // absent -> null; empty -> empty list; non-object elements skipped (Behavior B).
+            catalogItems = surrogate.catalogItems
+                ?.mapNotNull { it as? JsonObject }
+                ?.map { SelectCatalogItem(raw = it) },
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: SelectOffer) {
+        Surrogate.serializer().serialize(
+            encoder,
+            Surrogate(
+                campaignId = value.campaignId,
+                creative = value.creative,
+                catalogItems = value.catalogItems?.map { it.raw },
+            ),
+        )
+    }
+}
 
 /**
  * A catalog item from a v2 offers selection response.
@@ -107,13 +149,36 @@ data class SelectCatalogItem(
     /** The complete decoded payload, keyed by the raw (snake_case) JSON key. */
     val raw: JsonObject,
 ) {
-    /** Guaranteed by the server contract for every catalog item. */
+    /**
+     * Guaranteed by the server contract for every catalog item.
+     *
+     * Surfaced only when the wire value is a JSON string. If the server sends a
+     * non-string (number, bool, `null`, object, or array) for this guaranteed
+     * field — a server contract violation — this narrows to `null`,
+     * indistinguishable from the field being absent. This lossiness is
+     * deliberate: decoding never fails on shape drift. The original, untyped
+     * value is always preserved in [raw], so callers needing to observe a
+     * wrong-typed value can read [raw] directly.
+     */
     val instanceGuid: String?
-        get() = raw["instance_guid"]?.jsonPrimitive?.contentOrNull
+        get() = raw.stringValue("instance_guid")
 
-    /** Guaranteed by the server contract for every catalog item. */
+    /** Guaranteed by the server contract for every catalog item. See [instanceGuid]. */
     val title: String?
-        get() = raw["title"]?.jsonPrimitive?.contentOrNull
+        get() = raw.stringValue("title")
+
+    private companion object {
+        /**
+         * Reads [key] only when its wire value is an actual JSON string.
+         *
+         * `as? JsonPrimitive` is `null` for objects/arrays (so it never throws,
+         * unlike `jsonPrimitive`), and `isString` filters out unquoted
+         * number/bool/null literals so they narrow to `null` — matching the iOS
+         * `stringValue` narrowing exactly.
+         */
+        private fun JsonObject.stringValue(key: String): String? =
+            (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+    }
 }
 
 /**
@@ -128,13 +193,13 @@ internal object SelectCatalogItemSerializer : KSerializer<SelectCatalogItem> {
 
     override fun deserialize(decoder: Decoder): SelectCatalogItem {
         val input = decoder as? JsonDecoder
-            ?: error("SelectCatalogItem can only be deserialized from JSON")
+            ?: throw SerializationException("SelectCatalogItem can only be deserialized from JSON")
         return SelectCatalogItem(raw = delegate.deserialize(input))
     }
 
     override fun serialize(encoder: Encoder, value: SelectCatalogItem) {
         val output = encoder as? JsonEncoder
-            ?: error("SelectCatalogItem can only be serialized to JSON")
+            ?: throw SerializationException("SelectCatalogItem can only be serialized to JSON")
         delegate.serialize(output, value.raw)
     }
 }

--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -6,18 +6,9 @@ import com.rokt.network.model.LayoutDisplayPreset
 import com.rokt.network.model.LayoutSchemaModel
 import com.rokt.network.model.LayoutSettings
 import com.rokt.network.model.RootSchemaModel
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Selection response for an offers request — the model the renderer consumes,
@@ -81,128 +72,26 @@ data class SelectLayoutVariant(
     val layoutVariantSchema: LayoutSchemaModel? = null,
 )
 
-@Serializable(with = SelectOfferSerializer::class)
+@Serializable
 data class SelectOffer(
-    val campaignId: String? = null,
-    val creative: SelectCreative? = null,
-    val catalogItems: List<SelectCatalogItem>? = null,
+    @SerialName("campaign_id") val campaignId: String? = null,
+    @SerialName("creative") val creative: SelectCreative? = null,
+    @SerialName("catalog_items") val catalogItems: List<SelectCatalogItem>? = null,
 )
-
-/**
- * Decodes `catalog_items` as opaque [JsonElement]s first so a non-object element
- * (a bare string, number, null, nested array, etc.) does not fail the whole
- * response decode — consistent with the "never fail on shape drift" promise. Only
- * the object-shaped elements become typed [SelectCatalogItem]s; anything else is
- * skipped. An absent key stays `null`; an empty array stays an empty (non-null)
- * list. Mirrors the iOS `SelectOffer.init(from:)` resilient skip.
- */
-internal object SelectOfferSerializer : KSerializer<SelectOffer> {
-    @Serializable
-    private data class Surrogate(
-        @SerialName("campaign_id") val campaignId: String? = null,
-        @SerialName("creative") val creative: SelectCreative? = null,
-        @SerialName("catalog_items") val catalogItems: List<JsonElement>? = null,
-    )
-
-    override val descriptor: SerialDescriptor = Surrogate.serializer().descriptor
-
-    override fun deserialize(decoder: Decoder): SelectOffer {
-        val surrogate = Surrogate.serializer().deserialize(decoder)
-        return SelectOffer(
-            campaignId = surrogate.campaignId,
-            creative = surrogate.creative,
-            // absent -> null; empty -> empty list; non-object elements skipped (Behavior B).
-            catalogItems = surrogate.catalogItems
-                ?.mapNotNull { it as? JsonObject }
-                ?.map { SelectCatalogItem(raw = it) },
-        )
-    }
-
-    override fun serialize(encoder: Encoder, value: SelectOffer) {
-        Surrogate.serializer().serialize(
-            encoder,
-            Surrogate(
-                campaignId = value.campaignId,
-                creative = value.creative,
-                catalogItems = value.catalogItems?.map { it.raw },
-            ),
-        )
-    }
-}
 
 /**
  * A catalog item from an offers selection response.
  *
- * The transactions catalog-item shape is open and campaign-specific — only
- * [instanceGuid] and [title] are guaranteed; every other field varies by
- * campaign type. To stay type-safe without risking decode failures as that
- * shape changes, the guaranteed fields are surfaced as (optional) typed
- * accessors while the full payload is retained in [raw] so any
- * campaign-specific field still round-trips. Decoding never fails on an
- * unrecognised shape.
- *
- * When the renderer starts consuming catalog items, promote the fields it needs
- * from [raw] into typed (optional) properties here.
+ * Only `instance_guid` and `title` are part of the agreed contract, so they are
+ * the only fields modelled here. Both are optional; campaign-specific fields are
+ * intentionally not surfaced. As the renderer starts consuming catalog items,
+ * add the fields it needs as typed (optional) properties here.
  */
-@Serializable(with = SelectCatalogItemSerializer::class)
+@Serializable
 data class SelectCatalogItem(
-    /** The complete decoded payload, keyed by the raw (snake_case) JSON key. */
-    val raw: JsonObject,
-) {
-    /**
-     * Guaranteed by the server contract for every catalog item.
-     *
-     * Surfaced only when the wire value is a JSON string. If the server sends a
-     * non-string (number, bool, `null`, object, or array) for this guaranteed
-     * field — a server contract violation — this narrows to `null`,
-     * indistinguishable from the field being absent. This lossiness is
-     * deliberate: decoding never fails on shape drift. The original, untyped
-     * value is always preserved in [raw], so callers needing to observe a
-     * wrong-typed value can read [raw] directly.
-     */
-    val instanceGuid: String?
-        get() = raw.stringValue("instance_guid")
-
-    /** Guaranteed by the server contract for every catalog item. See [instanceGuid]. */
-    val title: String?
-        get() = raw.stringValue("title")
-
-    private companion object {
-        /**
-         * Reads [key] only when its wire value is an actual JSON string.
-         *
-         * `as? JsonPrimitive` is `null` for objects/arrays (so it never throws,
-         * unlike `jsonPrimitive`), and `isString` filters out unquoted
-         * number/bool/null literals so they narrow to `null` — matching the iOS
-         * `stringValue` narrowing exactly.
-         */
-        private fun JsonObject.stringValue(key: String): String? =
-            (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
-    }
-}
-
-/**
- * Captures the whole catalog-item object into [SelectCatalogItem.raw] so unknown
- * / campaign-specific fields are preserved, rather than mapping a fixed field
- * set. Keeps [raw] as the single source of truth for the wire shape.
- */
-internal object SelectCatalogItemSerializer : KSerializer<SelectCatalogItem> {
-    private val delegate = JsonObject.serializer()
-
-    override val descriptor: SerialDescriptor = delegate.descriptor
-
-    override fun deserialize(decoder: Decoder): SelectCatalogItem {
-        val input = decoder as? JsonDecoder
-            ?: throw SerializationException("SelectCatalogItem can only be deserialized from JSON")
-        return SelectCatalogItem(raw = delegate.deserialize(input))
-    }
-
-    override fun serialize(encoder: Encoder, value: SelectCatalogItem) {
-        val output = encoder as? JsonEncoder
-            ?: throw SerializationException("SelectCatalogItem can only be serialized to JSON")
-        delegate.serialize(output, value.raw)
-    }
-}
+    @SerialName("instance_guid") val instanceGuid: String? = null,
+    @SerialName("title") val title: String? = null,
+)
 
 @Serializable
 data class SelectCreative(

--- a/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/model/txn/SelectResponse.kt
@@ -20,8 +20,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
- * Selection response for a v2 offers request — the model the renderer consumes,
- * alongside the v1 `NetworkExperienceResponse`. The layout schema fields are
+ * Selection response for an offers request — the model the renderer consumes,
+ * alongside `NetworkExperienceResponse`. The layout schema fields are
  * parsed into the renderer's typed [RootSchemaModel] / [LayoutSchemaModel] (the
  * SDK-side wire model keeps the same fields as raw strings instead).
  */
@@ -131,7 +131,7 @@ internal object SelectOfferSerializer : KSerializer<SelectOffer> {
 }
 
 /**
- * A catalog item from a v2 offers selection response.
+ * A catalog item from an offers selection response.
  *
  * The transactions catalog-item shape is open and campaign-specific — only
  * [instanceGuid] and [title] are guaranteed; every other field varies by

--- a/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
@@ -2,13 +2,7 @@ package com.rokt.modelmapper.model.txn
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.double
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -50,13 +44,11 @@ class SelectResponseTest {
         assertEquals("campaign-1", offer.campaignId)
         assertEquals(1, offer.catalogItems?.size)
 
-        // Only `instance_guid` and `title` are guaranteed; campaign-specific
-        // fields vary by campaign type and round-trip via `raw`.
+        // Only `instance_guid` and `title` are part of the agreed contract; any
+        // campaign-specific fields in the payload are ignored.
         val catalogItem = offer.catalogItems!!.single()
         assertEquals("catalog-instance-1", catalogItem.instanceGuid)
         assertEquals("Catalog title", catalogItem.title)
-        assertEquals(9.99, catalogItem.raw["price"]?.jsonPrimitive?.double)
-        assertEquals("varies-by-campaign", catalogItem.raw["custom_field"]?.jsonPrimitive?.content)
 
         val creative = offer.creative!!
         assertEquals("creative-1", creative.referralCreativeId)
@@ -91,58 +83,15 @@ class SelectResponseTest {
 
     @Test
     fun `decodes a catalog item when the guaranteed fields are absent`() {
-        // The catalog-item shape is open and campaign-specific; only `instance_guid`
-        // and `title` are guaranteed. Decoding must not fail when they are absent —
-        // the typed accessors are null and the payload is retained in `raw`.
+        // Only `instance_guid` and `title` are modelled; both are optional, so
+        // decoding succeeds (with null values) when they are absent and any other
+        // fields in the payload are ignored (ignoreUnknownKeys).
         val catalogItem = json.decodeFromString<SelectCatalogItem>(
             """{ "campaign_only_field": 7, "nested": { "k": "v" } }""",
         )
 
         assertNull(catalogItem.instanceGuid)
         assertNull(catalogItem.title)
-        assertEquals(7, catalogItem.raw["campaign_only_field"]?.jsonPrimitive?.int)
-        assertEquals("v", catalogItem.raw["nested"]?.jsonObject?.get("k")?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun `catalog item narrows a non-string guaranteed field to null but retains it in raw`() {
-        // A guaranteed field arriving as a non-string is a server contract violation.
-        // Decoding deliberately tolerates it: the typed accessor narrows to null (the
-        // narrowing is lossy and pinned here on purpose), while the original value is
-        // always preserved untyped in `raw`.
-        val catalogItem = json.decodeFromString<SelectCatalogItem>(
-            """{ "instance_guid": 12345, "title": true }""",
-        )
-
-        assertNull(catalogItem.instanceGuid)
-        assertNull(catalogItem.title)
-        assertEquals(12345, catalogItem.raw["instance_guid"]?.jsonPrimitive?.int)
-        assertEquals(true, catalogItem.raw["title"]?.jsonPrimitive?.boolean)
-    }
-
-    @Test
-    fun `offer skips non-object catalog items without failing the decode`() {
-        // `catalog_items` is open; a non-object element (string, number, null, array)
-        // must not fail the whole response decode. Only object-shaped elements become
-        // typed items; everything else is skipped.
-        val offer = json.decodeFromString<SelectOffer>(
-            """
-            {
-              "campaign_id": "campaign-x",
-              "catalog_items": [
-                { "instance_guid": "keep-1", "title": "Kept" },
-                "bare-string",
-                42,
-                null,
-                ["nested", "array"],
-                { "instance_guid": "keep-2" }
-              ]
-            }
-            """.trimIndent(),
-        )
-
-        assertEquals(2, offer.catalogItems?.size)
-        assertEquals(listOf("keep-1", "keep-2"), offer.catalogItems!!.map { it.instanceGuid })
     }
 
     @Test
@@ -190,11 +139,8 @@ class SelectResponseTest {
                                         campaignId = "campaign-3",
                                         catalogItems = listOf(
                                             SelectCatalogItem(
-                                                raw = buildJsonObject {
-                                                    put("instance_guid", "catalog-instance-3")
-                                                    put("title", "Catalog title")
-                                                    put("price", 9.99)
-                                                },
+                                                instanceGuid = "catalog-instance-3",
+                                                title = "Catalog title",
                                             ),
                                         ),
                                         creative = SelectCreative(

--- a/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
@@ -2,6 +2,7 @@ package com.rokt.modelmapper.model.txn
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.int
@@ -101,6 +102,61 @@ class SelectResponseTest {
         assertNull(catalogItem.title)
         assertEquals(7, catalogItem.raw["campaign_only_field"]?.jsonPrimitive?.int)
         assertEquals("v", catalogItem.raw["nested"]?.jsonObject?.get("k")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `catalog item narrows a non-string guaranteed field to null but retains it in raw`() {
+        // A guaranteed field arriving as a non-string is a server contract violation.
+        // Decoding deliberately tolerates it: the typed accessor narrows to null (the
+        // narrowing is lossy and pinned here on purpose), while the original value is
+        // always preserved untyped in `raw`.
+        val catalogItem = json.decodeFromString<SelectCatalogItem>(
+            """{ "instance_guid": 12345, "title": true }""",
+        )
+
+        assertNull(catalogItem.instanceGuid)
+        assertNull(catalogItem.title)
+        assertEquals(12345, catalogItem.raw["instance_guid"]?.jsonPrimitive?.int)
+        assertEquals(true, catalogItem.raw["title"]?.jsonPrimitive?.boolean)
+    }
+
+    @Test
+    fun `offer skips non-object catalog items without failing the decode`() {
+        // `catalog_items` is open; a non-object element (string, number, null, array)
+        // must not fail the whole response decode. Only object-shaped elements become
+        // typed items; everything else is skipped.
+        val offer = json.decodeFromString<SelectOffer>(
+            """
+            {
+              "campaign_id": "campaign-x",
+              "catalog_items": [
+                { "instance_guid": "keep-1", "title": "Kept" },
+                "bare-string",
+                42,
+                null,
+                ["nested", "array"],
+                { "instance_guid": "keep-2" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(2, offer.catalogItems?.size)
+        assertEquals(listOf("keep-1", "keep-2"), offer.catalogItems!!.map { it.instanceGuid })
+    }
+
+    @Test
+    fun `offer distinguishes an empty catalog items array from an absent field`() {
+        // Absent key -> null; present-but-empty array -> empty (non-null) list.
+        val absentOffer = json.decodeFromString<SelectOffer>(
+            """{ "campaign_id": "campaign-absent" }""",
+        )
+        val emptyOffer = json.decodeFromString<SelectOffer>(
+            """{ "campaign_id": "campaign-empty", "catalog_items": [] }""",
+        )
+
+        assertNull(absentOffer.catalogItems)
+        assertTrue(emptyOffer.catalogItems!!.isEmpty())
     }
 
     @Test

--- a/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
@@ -20,8 +20,13 @@ class SelectResponseTest {
         assertEquals("token-1", response.sessionToken.token)
         assertEquals(1_711_038_600_000L, response.sessionToken.expiresAt)
         assertEquals("page-instance-1", response.pageInstanceGuid)
+        assertEquals("tag-1", response.pageContext?.roktTagId)
         assertEquals("page-1", response.pageContext?.pageId)
+        assertEquals("checkout", response.pageContext?.pageType)
         assertEquals("en", response.pageContext?.language)
+        assertEquals(true, response.pageContext?.isPageDetected)
+        assertEquals("variant-a", response.pageContext?.pageVariantName)
+        assertEquals("template-1", response.pageContext?.partnerContentTemplate)
 
         val plugin = response.plugins!!.single().plugin!!
         assertEquals("plugin-1", plugin.id)
@@ -115,9 +120,14 @@ class SelectResponseTest {
             sessionToken = SessionToken(token = "token-3", expiresAt = 42L),
             pageInstanceGuid = "page-instance-3",
             pageContext = SelectPageContext(
+                roktTagId = "tag-3",
                 pageInstanceGuid = "page-instance-3",
                 pageId = "page-3",
+                pageType = "checkout",
                 language = "en",
+                isPageDetected = true,
+                pageVariantName = "variant-a",
+                partnerContentTemplate = "template-3",
                 token = "ctx-token",
             ),
             plugins = listOf(
@@ -199,7 +209,7 @@ class SelectResponseTest {
               "session_id": "session-1",
               "session_token": { "token": "token-1", "expires_at": 1711038600000 },
               "page_instance_guid": "page-instance-1",
-              "page_context": { "page_instance_guid": "page-instance-1", "page_id": "page-1", "language": "en", "token": "ctx-token" },
+              "page_context": { "rokt_tag_id": "tag-1", "page_instance_guid": "page-instance-1", "page_id": "page-1", "page_type": "checkout", "language": "en", "is_page_detected": true, "page_variant_name": "variant-a", "partner_content_template": "template-1", "token": "ctx-token" },
               "plugins": [
                 {
                   "plugin": {

--- a/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
+++ b/roktux/src/test/java/com/rokt/modelmapper/model/txn/SelectResponseTest.kt
@@ -3,6 +3,10 @@ package com.rokt.modelmapper.model.txn
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -45,6 +49,14 @@ class SelectResponseTest {
         assertEquals("campaign-1", offer.campaignId)
         assertEquals(1, offer.catalogItems?.size)
 
+        // Only `instance_guid` and `title` are guaranteed; campaign-specific
+        // fields vary by campaign type and round-trip via `raw`.
+        val catalogItem = offer.catalogItems!!.single()
+        assertEquals("catalog-instance-1", catalogItem.instanceGuid)
+        assertEquals("Catalog title", catalogItem.title)
+        assertEquals(9.99, catalogItem.raw["price"]?.jsonPrimitive?.double)
+        assertEquals("varies-by-campaign", catalogItem.raw["custom_field"]?.jsonPrimitive?.content)
+
         val creative = offer.creative!!
         assertEquals("creative-1", creative.referralCreativeId)
         assertEquals("Hello", creative.copy?.get("title"))
@@ -77,6 +89,21 @@ class SelectResponseTest {
     }
 
     @Test
+    fun `decodes a catalog item when the guaranteed fields are absent`() {
+        // The catalog-item shape is open and campaign-specific; only `instance_guid`
+        // and `title` are guaranteed. Decoding must not fail when they are absent —
+        // the typed accessors are null and the payload is retained in `raw`.
+        val catalogItem = json.decodeFromString<SelectCatalogItem>(
+            """{ "campaign_only_field": 7, "nested": { "k": "v" } }""",
+        )
+
+        assertNull(catalogItem.instanceGuid)
+        assertNull(catalogItem.title)
+        assertEquals(7, catalogItem.raw["campaign_only_field"]?.jsonPrimitive?.int)
+        assertEquals("v", catalogItem.raw["nested"]?.jsonObject?.get("k")?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `round-trips a model built from the constructors`() {
         val original = SelectResponse(
             sessionId = "session-3",
@@ -105,7 +132,15 @@ class SelectResponseTest {
                                     ),
                                     offer = SelectOffer(
                                         campaignId = "campaign-3",
-                                        catalogItems = listOf(buildJsonObject { put("id", "catalog-3") }),
+                                        catalogItems = listOf(
+                                            SelectCatalogItem(
+                                                raw = buildJsonObject {
+                                                    put("instance_guid", "catalog-instance-3")
+                                                    put("title", "Catalog title")
+                                                    put("price", 9.99)
+                                                },
+                                            ),
+                                        ),
                                         creative = SelectCreative(
                                             referralCreativeId = "creative-3",
                                             instanceGuid = "creative-instance-3",
@@ -179,7 +214,7 @@ class SelectResponseTest {
                           "layout_variant": { "layout_variant_id": "variant-1", "module_name": "module-1" },
                           "offer": {
                             "campaign_id": "campaign-1",
-                            "catalog_items": [ { "id": "catalog-1" } ],
+                            "catalog_items": [ { "instance_guid": "catalog-instance-1", "title": "Catalog title", "price": 9.99, "custom_field": "varies-by-campaign" } ],
                             "creative": {
                               "referral_creative_id": "creative-1",
                               "instance_guid": "creative-instance-1",


### PR DESCRIPTION
## Background

- The v2 (transactions) selection-response `catalog_items` field was modelled as an opaque `List<JsonObject>` as an intentional interim. This mirrors the iOS follow-up to give the field a real type.
- The catalog-item shape is open and campaign-specific: only `instance_guid` and `title` are guaranteed, and every other field varies by campaign type. A fully-typed struct would risk decode failures as that shape changes.

## What Has Changed

- `SelectOffer.catalogItems` is now `List<SelectCatalogItem>?` instead of `List<JsonObject>?`.
- New `SelectCatalogItem` surfaces the two guaranteed fields (`instanceGuid`, `title`) as optional typed accessors while retaining the full payload in `raw` so campaign-specific fields still round-trip. A custom serializer captures the whole object, so decoding never fails on an unrecognised shape.
- Scope limited to `catalog_items`: `event_data.events` is deliberately left opaque, and no fields were converted to enums.

## Screenshots/Video

- N/A — model-only change, no rendering impact.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified locally: `./gradlew :roktux:testDebugUnitTest`, `:roktux:lintDebug`, and `:roktux:assembleDebug` all pass. Tests cover the typed fields, the `raw` fallback, decoding when the guaranteed fields are absent, and the constructor round-trip.