### PR TITLE
ci: support maintenance branch patch releases

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/*
       - workstation**
       - release**
   pull_request:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -42,6 +42,27 @@ jobs:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
     steps:
+      - name: Validate release branch
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump-type }}
+        run: |
+          release_branch="${GITHUB_REF_NAME}"
+          bump_type="${BUMP_TYPE}"
+
+          case "$release_branch" in
+            main|maintenance/*|workstation/*)
+              ;;
+            *)
+              echo "::error::Release drafts can only run from main, maintenance/*, or workstation/* branches."
+              exit 1
+              ;;
+          esac
+
+          if [[ "$release_branch" == maintenance/* && "$bump_type" != "patch" && "$bump_type" != "none" ]]; then
+            echo "::error::Maintenance branch releases must use a patch bump, or none when finalising an existing pre-release."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/*
       - workstation/*
 
 permissions:
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   setup-and-version:
+    if: ${{ !github.event.created && !github.event.deleted }}
     runs-on: ubuntu-latest
     outputs:
       full_release_needed: ${{ steps.version-changed.outputs.any_changed }}
@@ -44,7 +46,7 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [[ "$BRANCH" == workstation/* ]]; then
+          if [[ "$BRANCH" == maintenance/* || "$BRANCH" == workstation/* ]]; then
             echo "level=patch" >> $GITHUB_OUTPUT
           else
             echo "level=minor" >> $GITHUB_OUTPUT
@@ -192,7 +194,7 @@ jobs:
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: ${{ steps.concat-files.outputs.concatenated_files }}
-          makeLatest: ${{ needs.setup-and-version.outputs.is_prerelease == 'true' && 'false' || 'true' }}
+          makeLatest: ${{ needs.setup-and-version.outputs.is_prerelease != 'true' && github.ref_name == 'main' }}
           prerelease: ${{ needs.setup-and-version.outputs.is_prerelease == 'true' }}
           tag: ${{ needs.setup-and-version.outputs.full_release_version }}
           body: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,17 +8,17 @@ title: UX Helper releases overview
 gitGraph
     commit
     commit tag: "4.7.0"
-    branch workstation/4.7.x
-    checkout workstation/4.7.x
+    branch maintenance/4.7.x
+    checkout maintenance/4.7.x
     commit tag: "4.7.1"
     checkout main
-    merge workstation/4.7.x
+    merge maintenance/4.7.x
     commit
     commit
-    checkout workstation/4.7.x
+    checkout maintenance/4.7.x
     commit tag: "4.7.2"
     checkout main
-    merge workstation/4.7.x
+    merge maintenance/4.7.x
     commit
     commit tag: "4.8.0"
     commit
@@ -83,11 +83,11 @@ Hotfix / patch version e.g. releases that increase Z in the format X.Y.Z consist
 ```mermaid
 gitGraph
     commit tag: "4.7.0"
-    branch workstation/4.7.x
+    branch maintenance/4.7.x
     checkout main
     commit
     commit id: "Bug fix"
-    checkout workstation/4.7.x
+    checkout maintenance/4.7.x
     cherry-pick id:"Bug fix"
     commit tag: "4.7.1"
     checkout main
@@ -95,33 +95,41 @@ gitGraph
     commit
 ```
 
-1. Find and create a working branch in the format `workstation/X.Y.x` (e.g.
-   `workstation/4.7.x`) from the tagged commit you need to patch.
-2. On the workstation branch, make or cherry-pick the required changes.
-3. Run "Release – Draft" **with the branch selector set to `workstation/4.7.x`**
+1. Find and create a maintenance branch in the format `maintenance/X.Y.x` (e.g.
+   `maintenance/4.7.x`) from the tagged commit you need to patch. After a major
+   release such as `1.0.0`, create `maintenance/1.0.x` from the stable release
+   tag or release commit.
+2. On the maintenance branch, make or cherry-pick the required changes.
+3. Run "Release – Draft" **with the branch selector set to `maintenance/4.7.x`**
    (the "Use workflow from" dropdown). The draft workflow respects the dispatch
    branch and will:
-    - Check out, bump, and changelog against `workstation/4.7.x`.
-    - Open a PR targeting `workstation/4.7.x` (not `main`).
-4. Approve and merge the resulting `release-prep/...` PR into the workstation
+    - Check out, bump, and changelog against `maintenance/4.7.x`.
+    - Open a PR targeting `maintenance/4.7.x` (not `main`).
+    - Reject `minor` and `major` bumps on maintenance branches.
+4. Approve and merge the resulting `release-prep/...` PR into the maintenance
    branch.
-5. Once merged, `Release – Publish` will run from `workstation/4.7.x` and:
+5. Once merged, `Release – Publish` will run from `maintenance/4.7.x` and:
     - Upload the build to Maven Central.
-    - Create a GitHub release with the relevant build files.
+    - Create a GitHub release with the relevant build files. Maintenance
+      releases are not marked as GitHub "Latest"; only stable releases from
+      `main` update the latest release badge.
     - Tag the commit with the version number (e.g. `4.7.2`).
 
 > [!NOTE]
-> `Release – Publish` is triggered by pushes to `main` and `workstation/*`
-> branches only. Any other branch (e.g. `feat/...`, `chore/...`) will not
-> publish.
+> `Release – Publish` is triggered by pushes to `main`, `maintenance/*`, and
+> `workstation/*` branches only. Any other branch (e.g. `feat/...`,
+> `chore/...`) will not publish.
 >
 > Snapshot version logic:
 >
-> - On `workstation/*`, snapshots use a `patch` bump from the current `VERSION`
->   (so `workstation/4.7.x` at VERSION `4.7.1` produces `4.7.2-SNAPSHOT`).
+> - On `maintenance/*` and `workstation/*`, snapshots use a `patch` bump from
+>   the current `VERSION` (so `maintenance/4.7.x` at VERSION `4.7.1` produces
+>   `4.7.2-SNAPSHOT`).
 > - On `main`, snapshots use a `minor` bump (VERSION `4.7.1` → `4.8.0-SNAPSHOT`).
 > - If `VERSION` is already a pre-release (e.g. `1.0.0-rc1`), snapshots track
 >   the in-progress stable and emit `1.0.0-SNAPSHOT` instead of bumping further.
 >
 > The PR branch created by `Release – Draft` is named `release-prep/<version>`
 > so it does not collide with workstation or release branches.
+> `Release – Draft` can only run from `main`, `maintenance/*`, or
+> `workstation/*` branches.


### PR DESCRIPTION
## Background

- After the next stable UX Helper release lands on main, patch releases need to be cut from maintenance branches without moving the main release line backward.
- The release workflow currently publishes from main and workstation branches only, so maintenance branches cannot run the same patch release flow.
- The draft workflow should also prevent accidental release PRs from unsupported branch families or major/minor bumps on maintenance lines.

## What Has Changed

- Added maintenance branch support to the release publish workflow using the `maintenance/*` branch pattern.
- Added Release Draft validation so drafts only run from `main`, `maintenance/*`, or `workstation/*` branches.
- Rejected `major` and `minor` bumps on maintenance branches while preserving `patch` and `none` for pre-release finalisation.
- Made maintenance branch snapshots use patch version bumps, matching workstation patch behavior.
- Limited GitHub Latest updates to stable releases from `main`, so maintenance patch releases do not override newer major releases.
- Added pull request workflow coverage for pushes to `maintenance/*` branches.
- Updated the release guide to document the `maintenance/X.Y.x` patch release flow.

## Screenshots/Video

- N/A - workflow and documentation changes only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Local verification passed:
  - `trunk check --ci`
  - `./gradlew test --no-daemon --max-workers=2 -Dkotlin.daemon.jvm.options="-Xmx1g"`
