### PR TITLE
feat(roktux): include token on emitted platform events

### DIFF
--- a/roktux/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
+++ b/roktux/src/main/java/com/rokt/modelmapper/mappers/ExperienceModelMapperImpl.kt
@@ -502,7 +502,7 @@ class ExperienceModelMapperImpl(
 
     companion object {
         private const val KEY_ID = "id"
-        private const val KEY_TOKEN = "token"
+        const val KEY_TOKEN = "token"
         private const val KEY_SHORT_LABEL = "shortLabel"
         private const val KEY_LONG_LABEL = "longLabel"
         private const val KEY_SHORT_SUCCESS_LABEL = "shortSuccessLabel"

--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -137,6 +137,7 @@ data class RoktPlatformEvent(
     @SerialName("eventType") val eventType: EventType,
     @SerialName("sessionId") val sessionId: String,
     @SerialName("parentGuid") val parentGuid: String = "",
+    @SerialName("token") val token: String = "",
     @SerialName("pageInstanceGuid") val pageInstanceGuid: String = "",
     @SerialName("eventTime") val eventTime: String = roktDateFormat.format(Date()),
     @SerialName("eventData") val eventData: Map<String, String>? = null,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -10,6 +10,7 @@ import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_ACTI
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_INSTANCE_GUID
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_IS_POSITIVE
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_SIGNAL_TYPE
+import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_TOKEN
 import com.rokt.modelmapper.mappers.ExperienceModelMapperImpl.Companion.KEY_URL
 import com.rokt.modelmapper.mappers.ModelMapper
 import com.rokt.modelmapper.uimodel.Action
@@ -211,6 +212,7 @@ internal class LayoutViewModel(
                         eventType = EventType.SignalLoadComplete,
                         sessionId = experienceModel.sessionId,
                         parentGuid = pluginModel.instanceGuid,
+                        token = pluginModel.token,
                     ),
                 )
             }
@@ -226,6 +228,7 @@ internal class LayoutViewModel(
                         eventType = EventType.SignalActivation,
                         sessionId = experienceModel.sessionId,
                         parentGuid = pluginModel.instanceGuid,
+                        token = pluginModel.token,
                     ),
                 )
             }
@@ -373,6 +376,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalViewed,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.slots[offerId].offer?.creative?.instanceGuid.orEmpty(),
+                token = pluginModel.slots[offerId].offer?.creative?.token.orEmpty(),
                 pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
             ),
         )
@@ -385,6 +389,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalImpression,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
+                token = pluginModel.token,
                 metadata = listOf(
                     EventNameValue(KEY_PAGE_SIGNAL_LOAD_START, roktDateFormat.format(Date(startTimeStamp))),
                     EventNameValue(KEY_PAGE_RENDER_ENGINE, LAYOUTS_RENDER_ENGINE),
@@ -406,6 +411,7 @@ internal class LayoutViewModel(
                     eventType = EventType.SignalImpression,
                     sessionId = experienceModel.sessionId,
                     parentGuid = pluginModel.slots[id].instanceGuid,
+                    token = pluginModel.slots[id].token,
                 ),
             )
 
@@ -415,6 +421,7 @@ internal class LayoutViewModel(
                     eventType = EventType.SignalImpression,
                     sessionId = experienceModel.sessionId,
                     parentGuid = pluginModel.slots[id].offer?.creative?.instanceGuid.orEmpty(),
+                    token = pluginModel.slots[id].offer?.creative?.token.orEmpty(),
                 ),
             )
         }
@@ -440,6 +447,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalCartItemInstantPurchaseInitiated,
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItemProperties.instanceGuid(),
+                token = catalogItemProperties.token(),
                 eventData = catalogItemProperties.cartItemEventData(originalPrice),
             ),
         )
@@ -478,6 +486,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalCartItemInstantPurchaseInitiated,
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItemProperties.instanceGuid(),
+                token = catalogItemProperties.token(),
                 eventData = catalogItemProperties.cartItemEventData(salePrice),
             ),
         )
@@ -487,6 +496,7 @@ internal class LayoutViewModel(
         if (!runtimeState.validationCoordinator.validate(event.validatorFieldKeys)) {
             sendUserInteractionEvent(
                 parentGuid = event.catalogItemModel?.instanceGuid().orEmpty(),
+                token = event.catalogItemModel?.token().orEmpty(),
                 action = RoktUserInteractionAction.ValidationTriggerFailed,
                 context = RoktUserInteractionContext.CustomStateValidationTriggerButton,
             )
@@ -501,6 +511,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalCartItemInstantPurchaseInitiated,
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItemProperties.instanceGuid(),
+                token = catalogItemProperties.token(),
                 pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
                 objectData = catalogItemProperties.cartItemObjectData(),
             ),
@@ -566,6 +577,7 @@ internal class LayoutViewModel(
                 eventType = eventType,
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItem.instanceGuid,
+                token = catalogItem.token,
                 pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
             ),
         )
@@ -590,8 +602,10 @@ internal class LayoutViewModel(
         val parentGuid = event.parentGuid
             ?: event.catalogItemIndex?.let { index -> catalogItemInstanceGuid(event.offerId, index) }
             ?: return
+        val token = event.catalogItemIndex?.let { index -> catalogItemToken(event.offerId, index) }.orEmpty()
         sendUserInteractionEvent(
             parentGuid = parentGuid,
+            token = token,
             action = event.action,
             context = event.context,
         )
@@ -599,6 +613,7 @@ internal class LayoutViewModel(
 
     private fun sendUserInteractionEvent(
         parentGuid: String,
+        token: String,
         action: RoktUserInteractionAction,
         context: RoktUserInteractionContext,
     ) {
@@ -608,6 +623,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalUserInteraction,
                 sessionId = experienceModel.sessionId,
                 parentGuid = parentGuid,
+                token = token,
                 objectData = mapOf(
                     KEY_USER_INTERACTION_ACTION to action.name,
                     KEY_USER_INTERACTION_CONTEXT to context.name,
@@ -635,6 +651,7 @@ internal class LayoutViewModel(
                         eventType = eventType,
                         sessionId = experienceModel.sessionId,
                         parentGuid = parentGuid,
+                        token = token(),
                     ),
                 )
             }
@@ -759,6 +776,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalDismissal,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
+                token = pluginModel.token,
                 metadata = listOf(EventNameValue(KEY_INITIATOR, dismissReason)),
             ),
         )
@@ -770,6 +788,7 @@ internal class LayoutViewModel(
                 eventType = EventType.SignalInstantPurchaseDismissal,
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
+                token = pluginModel.token,
                 metadata = listOf(EventNameValue(KEY_INITIATOR, dismissReason)),
             ),
         )
@@ -927,13 +946,24 @@ internal class LayoutViewModel(
 
     private fun HMap.instanceGuid(): String = get<String>(KEY_INSTANCE_GUID).orEmpty()
 
-    private fun catalogItemInstanceGuid(offerId: Int, catalogItemIndex: Int): String? = pluginModel.slots
+    private fun HMap.token(): String = get<String>(KEY_TOKEN).orEmpty()
+
+    private fun catalogItemInstanceGuid(offerId: Int, catalogItemIndex: Int): String? = catalogItemProperties(
+        offerId,
+        catalogItemIndex,
+    )?.instanceGuid()
+
+    private fun catalogItemToken(offerId: Int, catalogItemIndex: Int): String? = catalogItemProperties(
+        offerId,
+        catalogItemIndex,
+    )?.token()
+
+    private fun catalogItemProperties(offerId: Int, catalogItemIndex: Int): HMap? = pluginModel.slots
         .getOrNull(offerId)
         ?.offer
         ?.catalogItems
         ?.getOrNull(catalogItemIndex)
         ?.properties
-        ?.instanceGuid()
 
     /**
      * Seeds offers whose device-pay purchase already completed into their post-purchase state
@@ -974,9 +1004,9 @@ internal class LayoutViewModel(
     )
 
     private fun HMap.toPendingDevicePayCatalogItem(): PendingDevicePayCatalogItem =
-        PendingDevicePayCatalogItem(instanceGuid = instanceGuid())
+        PendingDevicePayCatalogItem(instanceGuid = instanceGuid(), token = token())
 
-    private data class PendingDevicePayCatalogItem(val instanceGuid: String)
+    private data class PendingDevicePayCatalogItem(val instanceGuid: String, val token: String)
 
     companion object {
         private const val KEY_INITIATOR = "initiator"

--- a/roktux/src/test/java/com/rokt/roktux/event/RoktPlatformEventTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/event/RoktPlatformEventTest.kt
@@ -26,4 +26,18 @@ class RoktPlatformEventTest {
         assertEquals("ThumbnailClick", objectData.getValue("action").jsonPrimitive.content)
         assertEquals("CatalogImageGallery", objectData.getValue("context").jsonPrimitive.content)
     }
+
+    @Test
+    fun `RoktPlatformEvent serializes token`() {
+        val event = RoktPlatformEvent(
+            eventType = EventType.SignalImpression,
+            sessionId = "session-id",
+            parentGuid = "slot-instance-guid",
+            token = "slot-token",
+        )
+
+        val json = Json.parseToJsonElement(event.toJsonString()).jsonObject
+
+        assertEquals("slot-token", json.getValue("token").jsonPrimitive.content)
+    }
 }

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -65,12 +65,15 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     every { outerLayoutSchema } returns mockk(relaxed = true)
                     every { breakpoint } returns mockk(relaxed = true)
                     every { instanceGuid } returns "pluginInstanceGuid"
+                    every { token } returns "pluginToken"
                     every { slots } returns persistentListOf(
                         mockk(relaxed = true) {
                             every { instanceGuid } returns "slotInstanceGuid"
+                            every { token } returns "slotToken"
                             every { offer } returns mockk(relaxed = true) {
                                 every { creative } returns mockk(relaxed = true) {
                                     every { instanceGuid } returns "creativeInstanceGuid"
+                                    every { token } returns "creativeToken"
                                 }
                                 every { catalogItems } returns persistentListOf(
                                     CatalogItemModel(
@@ -81,6 +84,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                                         properties = createCatalogItemProperties(
                                             instanceGuid = "catalog-instance-guid-2",
                                             catalogItemId = "catalog-item-2",
+                                            token = "catalog-token-2",
                                         ),
                                         imageWrapper = CatalogImageWrapperModel(HMap()),
                                     ),
@@ -89,9 +93,11 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                         },
                         mockk(relaxed = true) {
                             every { instanceGuid } returns "slotInstanceGuid1"
+                            every { token } returns "slotToken1"
                             every { offer } returns mockk(relaxed = true) {
                                 every { creative } returns mockk(relaxed = true) {
                                     every { instanceGuid } returns "creativeInstanceGuid1"
+                                    every { token } returns "creativeToken1"
                                 }
                             }
                         },
@@ -187,6 +193,82 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
             platformEvent.invoke(
                 withArg { events ->
                     assertThat(events).anyMatch { it.eventType == EventType.SignalLoadComplete }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `LayoutReady Event sends SignalLoadComplete platform event carrying the plugin token`() = runTest {
+        // Act
+        layoutViewModel.setEvent(LayoutContract.LayoutEvent.LayoutReady)
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { event ->
+                        assertThat(event.eventType).isEqualTo(EventType.SignalLoadComplete)
+                        assertThat(event.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(event.token).isEqualTo("pluginToken")
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `ResponseOptionSelected sends SignalResponse platform event carrying the response option token`() = runTest {
+        // Arrange
+        val responseOptionProperties = HMap().apply {
+            this[TypedKey<Action>("action")] = Action.CaptureOnly
+            this[TypedKey<SignalType>("signalType")] = SignalType.SignalResponse
+            this[TypedKey<String>("instanceGuid")] = "responseInstanceGuid"
+            this[TypedKey<String>("token")] = "responseToken"
+        }
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.ResponseOptionSelected(
+                1,
+                OpenLinks.Internally,
+                responseOptionProperties,
+                true,
+            ),
+        )
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { event ->
+                        assertThat(event.eventType).isEqualTo(EventType.SignalResponse)
+                        assertThat(event.parentGuid).isEqualTo("responseInstanceGuid")
+                        assertThat(event.token).isEqualTo("responseToken")
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `CartItemForwardPaymentSelected sends platform event carrying the catalog item token`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, platformEvent, viewStateChange)
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemForwardPaymentSelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                transactionData = null,
+            ),
+        )
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { event ->
+                        assertThat(event.eventType).isEqualTo(EventType.SignalCartItemInstantPurchaseInitiated)
+                        assertThat(event.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(event.token).isEqualTo("catalog-token-1")
+                    }
                 },
             )
         }
@@ -1106,8 +1188,10 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
         catalogItemId: String = "catalog-item-1",
         price: Double = 79.99,
         originalPrice: Double = 99.99,
+        token: String = "catalog-token-1",
     ): HMap = HMap().apply {
         set(TypedKey<String>("instanceGuid"), instanceGuid)
+        set(TypedKey<String>("token"), token)
         set(TypedKey<String>("title"), "Everyday sneakers")
         set(TypedKey<String>("cartItemId"), "cart-item-1")
         set(TypedKey<String>("catalogItemId"), catalogItemId)


### PR DESCRIPTION
## Background

- The S2S UXHelper libraries for iOS and Android expose almost identical APIs, but the analytics/signal event object they emit differs: the iOS UXHelper already carries the `token` on every event it emits, while the Android UXHelper emitted events without a token and left the consuming SDK to reconstruct it from the experience response.
- This change brings Android to parity with iOS so the token is populated by the UXHelper itself, at the point each event is created.

## What Has Changed

- Added a `token` field to `RoktPlatformEvent`.
- `LayoutViewModel` now sets the token of the relevant parent entity (plugin, slot, creative, response option, or catalog item) on every emitted platform event; diagnostic events keep an empty token.
- Added `HMap.token()` and `catalogItemToken()` helpers, threaded the token through user-interaction events, and carried it on `PendingDevicePayCatalogItem`.
- Exposed the shared `KEY_TOKEN` constant.
- Added unit tests asserting the correct token is emitted per entity level and that the token serializes.

## Screenshots/Video

- N/A — no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Paired with the consuming change in `sdk-android-source` (`feat(roktsdk): use the token carried on platform events`), which removes the SDK-side token map. This UXHelper change is additive and backward compatible (the new field defaults to empty), so it can merge independently.