### PR TITLE
fix(toggle-button): send user interaction signal

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/component/button/ToggleButtonStateTriggerComponent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/component/button/ToggleButtonStateTriggerComponent.kt
@@ -6,6 +6,8 @@ import com.rokt.modelmapper.uimodel.LayoutSchemaUiModel
 import com.rokt.roktux.component.ComposableComponent
 import com.rokt.roktux.component.LayoutUiModelFactory
 import com.rokt.roktux.component.ModifierFactory
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.viewmodel.layout.LayoutContract
 import com.rokt.roktux.viewmodel.layout.OfferUiState
 
@@ -41,6 +43,13 @@ internal class ToggleButtonStateTriggerComponent(
                 0
             }
             onEventSent(LayoutContract.LayoutEvent.SetCustomState(model.customStateKey, newState))
+            onEventSent(
+                LayoutContract.LayoutEvent.UserInteractionSelected(
+                    offerId = offerState.currentOfferIndex,
+                    action = RoktUserInteractionAction.ToggleButtonStateTriggerClick,
+                    context = RoktUserInteractionContext.ToggleButtonStateTrigger,
+                ),
+            )
         }
     }
 }

--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -213,12 +213,14 @@ internal enum class RoktUserInteractionAction {
     MainImageScrollIconRightClick,
     MainImageSwipeLeft,
     MainImageSwipeRight,
+    ToggleButtonStateTriggerClick,
 }
 
 internal enum class RoktUserInteractionContext {
     CustomStateValidationTriggerButton,
     CatalogDropDown,
     CatalogImageGallery,
+    ToggleButtonStateTrigger,
 }
 
 internal fun SignalType.toEventType(): EventType = when (this) {

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -601,7 +601,7 @@ internal class LayoutViewModel(
     private fun handleUserInteractionSelected(event: LayoutContract.LayoutEvent.UserInteractionSelected) {
         val parentGuid = event.parentGuid
             ?: event.catalogItemIndex?.let { index -> catalogItemInstanceGuid(event.offerId, index) }
-            ?: return
+            ?: pluginModel.instanceGuid
         val token = event.catalogItemIndex?.let { index -> catalogItemToken(event.offerId, index) }.orEmpty()
         sendUserInteractionEvent(
             parentGuid = parentGuid,

--- a/roktux/src/test/java/com/rokt/roktux/component/ToggleButtonComponentTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/component/ToggleButtonComponentTest.kt
@@ -9,8 +9,11 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rokt.core.testutils.annotations.DCUI_COMPONENT_TAG
 import com.rokt.core.testutils.annotations.DcuiNodeJson
+import com.rokt.roktux.event.RoktUserInteractionAction
+import com.rokt.roktux.event.RoktUserInteractionContext
 import com.rokt.roktux.testutil.BaseDcuiEspressoTest
 import com.rokt.roktux.viewmodel.layout.LayoutContract
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,5 +40,10 @@ class ToggleButtonComponentTest : BaseDcuiEspressoTest() {
         Assert.assertTrue(
             getCapturedEvents().any { e -> e.equals(LayoutContract.LayoutEvent.SetCustomState("ToggleButtonState", 1)) },
         )
+        assertThat(getCapturedEvents().filterIsInstance<LayoutContract.LayoutEvent.UserInteractionSelected>())
+            .anySatisfy { event ->
+                assertThat(event.action).isEqualTo(RoktUserInteractionAction.ToggleButtonStateTriggerClick)
+                assertThat(event.context).isEqualTo(RoktUserInteractionContext.ToggleButtonStateTrigger)
+            }
     }
 }

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -986,6 +986,39 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `UserInteractionSelected sends layout scoped SignalUserInteraction with plugin parent guid`() = runTest {
+        // Arrange
+        clearMocks(platformEvent)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.UserInteractionSelected(
+                offerId = 0,
+                action = RoktUserInteractionAction.ToggleButtonStateTriggerClick,
+                context = RoktUserInteractionContext.ToggleButtonStateTrigger,
+            ),
+        )
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
+                        assertThat(platformEvent.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(platformEvent.objectData).isEqualTo(
+                            mapOf(
+                                "action" to "ToggleButtonStateTriggerClick",
+                                "context" to "ToggleButtonStateTrigger",
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
     fun `UserInteractionSelected sends SignalUserInteraction with object data`() = runTest {
         // Arrange
         clearMocks(platformEvent)


### PR DESCRIPTION
## Background

- `ToggleButtonStateTrigger` toggles custom state on tap but did not emit a user-interaction signal.
- That made layout-scoped toggle taps invisible to event consumers and dashboards, unlike iOS/web behavior.
- Android parity work follows the iOS implementation in [rokt-ux-helper-ios#316](https://github.com/ROKT/rokt-ux-helper-ios/pull/316).

## What Has Changed

- Added `ToggleButtonStateTriggerClick` and `ToggleButtonStateTrigger` user-interaction action/context values.
- Updated `ToggleButtonStateTriggerComponent` to emit `UserInteractionSelected` alongside the existing custom-state toggle.
- Updated `LayoutViewModel` to resolve layout-scoped user interactions to `pluginModel.instanceGuid` when no catalog item parent is provided.
- Added component and view model tests for the new behavior.

## Screenshots/Video

- Not applicable. This is an event behavior change with no intended UI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. Not applicable; no public documentation change needed.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local validation:
  - `trunk check`
  - `./gradlew :roktux:testDebugUnitTest --tests "com.rokt.roktux.viewmodel.RoktLayoutViewModelTest"`
  - `./gradlew :roktux:testDebugUnitTest --tests "com.rokt.roktux.component.ToggleButtonComponentTest"`

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A