### PR TITLE
feat: emit OfferProgression on buy-now validation success

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
+++ b/roktux/src/main/java/com/rokt/roktux/event/RoktEvent.kt
@@ -206,6 +206,7 @@ enum class EventType {
 data class EventNameValue(@SerialName("name") val name: String, @SerialName("value") val value: String)
 
 internal enum class RoktUserInteractionAction {
+    OfferProgression,
     ValidationTriggerFailed,
     DropDownItemSelected,
     ThumbnailClick,

--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -504,6 +504,12 @@ internal class LayoutViewModel(
         }
 
         val catalogItemProperties = event.catalogItemModel ?: return
+        sendUserInteractionEvent(
+            parentGuid = catalogItemProperties.instanceGuid(),
+            token = catalogItemProperties.token(),
+            action = RoktUserInteractionAction.OfferProgression,
+            context = RoktUserInteractionContext.CustomStateValidationTriggerButton,
+        )
         val salePrice = catalogItemProperties.salePrice()
         pendingDevicePayCatalogItem = catalogItemProperties.toPendingDevicePayCatalogItem()
         handlePlatformEvent(

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -939,6 +939,41 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `CartItemDevicePaySelected sends OfferProgression when validation passes`() = runTest {
+        // Arrange
+        clearMocks(platformEvent, uxEvent)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemDevicePaySelected(
+                offerId = 0,
+                catalogItemModel = createCatalogItemProperties(),
+                paymentProvider = PaymentProvider.GooglePay,
+                transactionData = null,
+                validatorFieldKeys = emptyList(),
+            ),
+        )
+
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { platformEvent ->
+                        assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
+                        assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.objectData).isEqualTo(
+                            mapOf(
+                                "action" to "OfferProgression",
+                                "context" to "CustomStateValidationTriggerButton",
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
     fun `CartItemDevicePaySelected does not emit event when validation fails`() = runTest {
         // Arrange
         val validationCoordinator = ValidationCoordinator()


### PR DESCRIPTION
## Background

Shoppable Ads placements need a `SignalUserInteraction` when customers tap the Buy Now button on the View Offer screen. iOS already emits `OfferProgression` for this flow; Android was missing the signal on successful validation.

## What Has Changed

- Emit `SignalUserInteraction` with action `OfferProgression` and context `CustomStateValidationTriggerButton` when `CatalogDevicePayButton` validation passes
- Add `OfferProgression` to `RoktUserInteractionAction`
- Add unit test covering the successful-validation path

## Screenshots/Video

N/A — platform event emission only.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

Matches iOS parity from `CatalogDevicePayButtonViewModel.handleTap()`. Validation failure continues to emit `ValidationTriggerFailed`.