### PR TITLE
feat(events): populate interactionType on user_interaction objectData

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -633,6 +633,9 @@ internal class LayoutViewModel(
                 objectData = mapOf(
                     KEY_USER_INTERACTION_ACTION to action.name,
                     KEY_USER_INTERACTION_CONTEXT to context.name,
+                    // Canonical classification the ledger reads; mirrors action so downstream
+                    // consumers get a populated interactionType without SDK-side derivation.
+                    KEY_USER_INTERACTION_INTERACTION_TYPE to action.name,
                 ),
             ),
         )
@@ -1018,6 +1021,7 @@ internal class LayoutViewModel(
         private const val KEY_INITIATOR = "initiator"
         private const val KEY_USER_INTERACTION_ACTION = "action"
         private const val KEY_USER_INTERACTION_CONTEXT = "context"
+        private const val KEY_USER_INTERACTION_INTERACTION_TYPE = "interactionType"
         private const val KEY_PAGE_RENDER_ENGINE = "pageRenderEngine"
         private const val KEY_PAGE_SIGNAL_LOAD_START = "pageSignalLoadStart"
         private const val KEY_PAGE_SIGNAL_LOAD_COMPLETE = "pageSignalLoadComplete"

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -965,6 +965,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                             mapOf(
                                 "action" to "OfferProgression",
                                 "context" to "CustomStateValidationTriggerButton",
+                                "interactionType" to "OfferProgression",
                             ),
                         )
                     }
@@ -1012,6 +1013,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                             mapOf(
                                 "action" to "ValidationTriggerFailed",
                                 "context" to "CustomStateValidationTriggerButton",
+                                "interactionType" to "ValidationTriggerFailed",
                             ),
                         )
                     }
@@ -1045,6 +1047,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                             mapOf(
                                 "action" to "ToggleButtonStateTriggerClick",
                                 "context" to "ToggleButtonStateTrigger",
+                                "interactionType" to "ToggleButtonStateTriggerClick",
                             ),
                         )
                     }
@@ -1079,6 +1082,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                             mapOf(
                                 "action" to "ThumbnailClick",
                                 "context" to "CatalogImageGallery",
+                                "interactionType" to "ThumbnailClick",
                             ),
                         )
                     }
@@ -1113,6 +1117,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                             mapOf(
                                 "action" to "DropDownItemSelected",
                                 "context" to "CatalogDropDown",
+                                "interactionType" to "DropDownItemSelected",
                             ),
                         )
                     }


### PR DESCRIPTION
## Background

`user_interaction` events carry `action`/`context` in `objectData`, but the transactions ledger reads a canonical `interactionType` key. Per review on the SDK side (ROKT/sdk-android-source #1123), that classification logic belongs here — in the UX helper, where the event's `objectData` is constructed — so the SDK simply flattens `objectData` verbatim onto the v2 wire with no derivation logic.

## What Has Changed

- Add `KEY_USER_INTERACTION_INTERACTION_TYPE = "interactionType"`.
- Populate `interactionType` (mirroring the `action` value) in the `sendUserInteractionEvent` `objectData` map in `LayoutViewModel`.
- Device-pay (`cartItemObjectData`) and other events are unaffected.
- `RoktLayoutViewModelTest` assertions updated to expect `interactionType` alongside `action`/`context` for all user_interaction cases.

## Follow-up (separate PRs, not here)

- rokt-ux-helper-ios: the sibling change (ROKT/rokt-ux-helper-ios feat/user-interaction-type).
- sdk-android-source: once this ships in a roktux release, bump the `roktUxHelper` version — `interactionType` then arrives via the existing verbatim flatten (#1123). `SignalActivation`'s `interactionType:"activation"` stays in the SDK mapper (event-type → wire mapping, not objectData-derived).

## How Has This Been Tested

- `./gradlew :roktux:testDebugUnitTest --tests "*RoktLayoutViewModelTest*"` — pass.
- `trunk check` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)