### PR TITLE
chore(snapshot): update Roborazzi screenshot testing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ enableComposeCompilerMetrics=true
 enableComposeCompilerReports=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+roborazzi.cleanupOldScreenshots=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ kover = "0.9.1"
 
 roktUxHelper = "0.2.0"
 sdkVersionCode = "79"
-roborazzi = "1.43.0"
+roborazzi = "1.60.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }

--- a/roktux/build.gradle.kts
+++ b/roktux/build.gradle.kts
@@ -45,8 +45,8 @@ android {
             isIncludeAndroidResources = true
             all {
                 it.useJUnit {
-                    // Run screenshot tests by using -PrunSnapshotTests
-                    if (project.hasProperty("runSnapshotTests")) {
+                    // Run screenshot tests by using -PenableSnapshotTests
+                    if (project.hasProperty("enableSnapshotTests")) {
                         includeCategories("com.rokt.roktux.snapshot.SnapshotTest")
                     }
                 }

--- a/roktux/src/test/README.md
+++ b/roktux/src/test/README.md
@@ -8,6 +8,14 @@ We use [Roborazzi](https://github.com/takahirom/roborazzi) for snapshot testing.
 
 To separate snapshot tests from regular unit tests, you can use the `@Category(SnapshotTest::class)` annotation for each test class. When running a test command, include `-PenableSnapshotTests` to also make the snapshot tests run. If you are not using a Roborazzi task (e.g. running `./gradlew test` instead of `./gradlew verifyRoborazziRelease`) you will also need to include the Roborazzi properties `-Proborazzi.test.record=true`, `-Proborazzi.test.compare=true`, and `-Proborazzi.test.verify=true` depending on which task you want to execute.
 
+### IDE Plugin
+
+The JetBrains Marketplace plugin for Roborazzi renders screenshot diffs directly in Android Studio and IntelliJ IDEA. Search for "Roborazzi" in the IDE plugin marketplace, or install plugin ID `24561`.
+
+### Debugging
+
+When a snapshot verification fails locally, add `-Proborazzi.debug=true` to the Gradle command to emit verbose path and comparison diagnostics.
+
 ### Updating Baselines
 
 To ensure consistency of the environment used for snapshot testing, baseline images should be created via CI.


### PR DESCRIPTION
## Background

- Roborazzi snapshot testing was behind the latest version that is compatible with the current Kotlin toolchain.
- The documented snapshot test flag did not match the Gradle category filter, so documented commands could skip the intended snapshot-test category setup.
- Snapshot test contributors need clearer local tooling notes for diff review and failed comparison diagnostics.

## What Has Changed

- Updated Roborazzi from `1.43.0` to `1.60.0`, the newest compatible version before newer artifacts require Kotlin metadata unsupported by the current toolchain.
- Changed the snapshot category gate from `-PrunSnapshotTests` to the documented `-PenableSnapshotTests` property.
- Enabled Roborazzi cleanup of stale screenshot outputs.
- Documented the Roborazzi IDE plugin and `-Proborazzi.debug=true` diagnostics flag.
- Refreshed the affected screenshot baselines and verified them with Roborazzi.

## Screenshots/Video

The Android studio plugin shows a preview of the tests when a test file is opened.

<img width="286" height="1203" alt="Screenshot 2026-07-28 at 1 43 52 pm" src="https://github.com/user-attachments/assets/151981d3-413d-4ae0-91c8-212230863c3c" />


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local verification completed with `./gradlew build`, `./gradlew test`, `./gradlew lint`, `./gradlew verifyRoborazziRelease -PenableSnapshotTests --tests "com.rokt.roktux.snapshot.*"`, and `trunk check --ci`.