### PR TITLE
ci: cache Gradle User Home in the snapshot-test job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -156,6 +156,11 @@ jobs:
       - name: Setup JDK
         uses: ./.github/actions/setup-java
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+
       - name: Move snapshots
         run: |
           mkdir -p roktux/build/outputs/roborazzi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- `snapshot-test` is the only Gradle job in `pull-request.yml` without a `Setup Gradle` step. `lint`, `unit-test` and `assemble-debug` all run `gradle/actions/setup-gradle`; `snapshot-test` sets up the JDK and goes straight to `./gradlew verifyRoborazziRelease`.
- Measured consequence on a recent run of the job:

  ```
  Downloading https://services.gradle.org/distributions/gradle-8.9-bin.zip
  59 actionable tasks: 54 executed, 5 from cache
  ```

  The Gradle distribution is re-downloaded on every run, and the job reuses almost nothing.

- For comparison, the same run's `unit-test` job restored a ~747 MB Gradle User Home entry (`Cache hit for: setup-java-Linux-x64-gradle-…`, `Cache restored successfully`) and had a long tail of `FROM-CACHE` tasks.
- The cache this job is missing out on already exists and is already being written — no new infrastructure is needed. setup-gradle defaults `gradle-home-cache-strict-match` to `false`, meaning it will restore entries populated by *other* jobs; confirmed by `lint` and `assemble-debug` both restoring the identical key `setup-java-Linux-x64-gradle-b2e071c7…`. Entries are written from `main` because `pull-request.yml` also triggers on pushes to `main`.

## What Has Changed

- `pull-request.yml` — added the same `Setup Gradle` step (`gradle/actions/setup-gradle` v6.2.0, `cache-provider: basic`) to `snapshot-test` that the other three Gradle jobs already use.

Placed after `Setup JDK` and before `Move snapshots`, matching the existing job order. The action pin and inputs are copied verbatim from the sibling jobs, so there is no new action version or configuration to review.

No change to what the job verifies — Roborazzi still runs against the moved snapshot images exactly as before.

## Screenshots/Video

- N/A (CI configuration change).

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. — N/A.
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A; no test can cover a runner's cache behaviour. See verification below.
- [x] I have tested this locally. — `actionlint` and `trunk check` clean.

## Verification

Read the `snapshot-test` job log on this PR and compare against the numbers in Background:

- [ ] No `Downloading https://services.gradle.org/distributions/gradle-8.9-bin.zip` line.
- [ ] A `Basic caching restored from cache key: …` line appears.
- [ ] `from cache` count materially above the previous 5 of 59.

Snapshot verification itself must still pass — that is the regression to watch, since this job is the one that gates visual output.

## Additional Notes

This job only ever **reads** the cache on a PR: setup-gradle applies `cache-read-only: true` off the default branch. It starts contributing entries once the change is on `main`, so expect the first `main` run to be the one that adds a `snapshot-test`-flavoured entry.

Storage impact is small. Entries are keyed on the Gradle build files, and restore falls back across jobs, so this adds at most one more entry per key generation rather than one per job per commit.

Deliberately out of scope:

- The `setup-java` composite writes `~/.gradle/gradle.properties` *before* setup-gradle runs. That is safe — setup-gradle only disables its own caching when `~/.gradle/caches` already exists, and `mkdir -p ~/.gradle` does not create it. Verified by the cache hits in the existing jobs; no reordering needed.
- `org.gradle.workers.max=1` / `org.gradle.parallel=false` in the `setup-java` composite are the next lever for these jobs, but they are a separate change with a different risk profile.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A — CI performance fix, no ticket.
