### PR TITLE
ci: skip Dependabot-incompatible steps on Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Generate coverage
         run: ./gradlew koverXmlReport
       - name: Upload Test Report
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./roktux/build/reports/kover/report.xml
@@ -184,6 +185,7 @@ jobs:
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     needs: [trunk-check, lint, unit-test, assemble-debug, snapshot-test]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Every Dependabot PR whose build otherwise passes shows exactly one red check: `Notify GChat / notify-gchat`, failing in ~4s with `Input required and not supplied: webhookUrl`. That single red check hides whether the bump is actually mergeable.
- Cause: Dependabot-triggered runs resolve the `secrets` context against a **separate, repository-scoped store**, which is empty for this repo (`dependabot/secrets` → `total_count: 0`). `GCHAT_PRS_MOBILE_INTEGRATION_CHANNEL_WEBHOOK` lives in the Actions store, so `gchat_webhook` arrives blank. The failing job's own log confirms the switch: `Secret source: Dependabot`, with `GITHUB_TOKEN Permissions` reduced to `Contents: read`, `Metadata: read`.
- `pr-notify` uses `always()`, so it runs even when its dependencies skip. Nothing in the existing `if` can prevent it from reaching the notifier on a Dependabot run, so the guard has to be explicit.
- `CODECOV_TOKEN` is unavailable for the same reason. That one does **not** fail the job — `codecov-action` logs `Upload queued for processing failed: {"message":"Token required because branch is protected"}` and exits 0 — so coverage has been silently not uploading on Dependabot PRs while the step reported success.

Reproduced on both recent Dependabot PRs where the build passed:

| PR | Build jobs | `Notify GChat` |
|---|---|---|
| #303 (`actions/checkout` 6.0.3 → 7.0.1) | all pass | **fail**, 4s |
| #286 (`gradle/actions` 6.1.0 → 6.2.0) | all pass | **fail**, 4s |

Confirmed in the other direction too: on Dependabot PRs where a build job genuinely failed (#271, #272), `Notify GChat` reports *skipping* via the existing `!contains(needs.*.result, 'failure')` guard — so this is specific to the secrets store, not to the notifier itself.

## What Has Changed

- `pull-request.yml` — added `github.actor != 'dependabot[bot]'` to the `pr-notify` job's `if`.
- `pull-request.yml` — added the same condition to the Codecov upload step in `unit-test`.

`github.actor` is used deliberately: it is exactly what GitHub uses to decide which secrets store a run reads from, so the guard matches the precise condition under which the secrets are unavailable. A human pushing to a Dependabot branch gets the normal secrets and normal behaviour.

Skipped checks do not block merge, so Dependabot PRs now go green.

## Screenshots/Video

- N/A (CI configuration change).

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. — N/A; the rationale is captured in the commit message and this description.
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A; workflow `if` conditions are not unit-testable. See verification below.
- [x] I have tested this locally. — `actionlint` and `trunk check` clean.

## Verification

This PR cannot demonstrate the fix on itself: it is human-authored, so both the notifier and the Codecov upload run normally here. **A green run proves the guards do not break the happy path, which is the important regression to check** — `Notify GChat` must still report success on this PR, and coverage must still upload.

Proving the Dependabot path needs a Dependabot-triggered run after merge: re-run #303 or #286 and `Notify GChat` should report **skipped** rather than **failed**.

## Additional Notes

**Tradeoff on the Codecov guard.** Dependabot PRs no longer attempt a coverage upload at all. They were never successfully uploading — the guard only removes a misleading error line from the log. If Codecov's PR comment on dependency bumps is wanted later, the fix is to add `CODECOV_TOKEN` to the Dependabot secrets store, not to revert this.

**Alternative considered and rejected.** Adding the webhook to the Dependabot secrets store would also work, but it hands a notification credential to runs whose workflow definitions Dependabot itself rewrites. Not worth it to un-red a notification.

**Not addressed.** The `pr-notify` caller grants `id-token: write`, but the reusable notifier's only step POSTs to the webhook and never requests an OIDC token. That is unnecessary privilege worth dropping upstream, out of scope here.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A — CI reliability fix, no ticket.
