### PR TITLE
feat(signal-response): include click destination URL metadata

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -654,6 +654,7 @@ internal class LayoutViewModel(
             }
             val eventType = get<SignalType>(KEY_SIGNAL_TYPE)?.toEventType()
             val parentGuid = get<String>(KEY_INSTANCE_GUID)
+            val responseUrl = get<String>(KEY_URL)?.takeIf { it.isNotEmpty() }
             if (eventType != null && parentGuid != null) {
                 handlePlatformEvent(
                     RoktPlatformEvent(
@@ -661,11 +662,16 @@ internal class LayoutViewModel(
                         sessionId = experienceModel.sessionId,
                         parentGuid = parentGuid,
                         token = token(),
+                        metadata = buildList {
+                            if (get<Action>(KEY_ACTION) == Action.Url && responseUrl != null) {
+                                add(EventNameValue(KEY_TRANSFORMED_TRAFFIC_URL, responseUrl))
+                            }
+                        },
                     ),
                 )
             }
             if (get<Action>(KEY_ACTION) == Action.Url) {
-                sendOpenUrlEvent(get<String>(KEY_URL).orEmpty(), openLinks, true, shouldProgress)
+                sendOpenUrlEvent(responseUrl.orEmpty(), openLinks, true, shouldProgress)
             } else {
                 if (shouldProgress) {
                     updateTargetOffer(currentOffer + 1)
@@ -1019,6 +1025,7 @@ internal class LayoutViewModel(
 
     companion object {
         private const val KEY_INITIATOR = "initiator"
+        private const val KEY_TRANSFORMED_TRAFFIC_URL = "transformedTrafficURL"
         private const val KEY_USER_INTERACTION_ACTION = "action"
         private const val KEY_USER_INTERACTION_CONTEXT = "context"
         private const val KEY_USER_INTERACTION_INTERACTION_TYPE = "interactionType"

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -242,6 +242,44 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                         assertThat(event.eventType).isEqualTo(EventType.SignalResponse)
                         assertThat(event.parentGuid).isEqualTo("responseInstanceGuid")
                         assertThat(event.token).isEqualTo("responseToken")
+                        assertThat(event.metadata.map { it.name }).doesNotContain("transformedTrafficURL")
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `ResponseOptionSelected Url action sends SignalResponse with click destination URL`() = runTest {
+        // Arrange
+        val responseOptionProperties = HMap().apply {
+            this[TypedKey<Action>("action")] = Action.Url
+            this[TypedKey<SignalType>("signalType")] = SignalType.SignalResponse
+            this[TypedKey<String>("instanceGuid")] = "responseInstanceGuid"
+            this[TypedKey<String>("token")] = "responseToken"
+            this[TypedKey<String>("url")] = "https://example.com/offer"
+        }
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.ResponseOptionSelected(
+                1,
+                OpenLinks.Internally,
+                responseOptionProperties,
+                true,
+            ),
+        )
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { event ->
+                        assertThat(event.eventType).isEqualTo(EventType.SignalResponse)
+                        assertThat(event.parentGuid).isEqualTo("responseInstanceGuid")
+                        assertThat(event.token).isEqualTo("responseToken")
+                        assertThat(event.metadata).anySatisfy { metadata ->
+                            assertThat(metadata.name).isEqualTo("transformedTrafficURL")
+                            assertThat(metadata.value).isEqualTo("https://example.com/offer")
+                        }
                     }
                 },
             )

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -287,6 +287,40 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `ResponseOptionSelected Url action with empty URL omits click destination metadata`() = runTest {
+        // Arrange
+        val responseOptionProperties = HMap().apply {
+            this[TypedKey<Action>("action")] = Action.Url
+            this[TypedKey<SignalType>("signalType")] = SignalType.SignalResponse
+            this[TypedKey<String>("instanceGuid")] = "responseInstanceGuid"
+            this[TypedKey<String>("token")] = "responseToken"
+            this[TypedKey<String>("url")] = ""
+        }
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.ResponseOptionSelected(
+                1,
+                OpenLinks.Internally,
+                responseOptionProperties,
+                true,
+            ),
+        )
+        // Assert
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                withArg { events ->
+                    assertThat(events).anySatisfy { event ->
+                        assertThat(event.eventType).isEqualTo(EventType.SignalResponse)
+                        assertThat(event.parentGuid).isEqualTo("responseInstanceGuid")
+                        assertThat(event.token).isEqualTo("responseToken")
+                        assertThat(event.metadata.map { it.name }).doesNotContain("transformedTrafficURL")
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
     fun `CartItemForwardPaymentSelected sends platform event carrying the catalog item token`() = runTest {
         // Arrange
         clearMocks(uxEvent, platformEvent, viewStateChange)


### PR DESCRIPTION
## Background

- Web already sends the click destination on Url `SignalResponse` events as `transformedTrafficURL`. Android omitted it, so engagement/attribution could not see where the user was sent after the tap.

## What Has Changed

- On Url response option selection, attach `transformedTrafficURL` metadata to the `SignalResponse` / gated response platform event when a non-empty URL is present.
- CaptureOnly responses still omit the field.
- Added unit coverage for both paths.

## Screenshots/Video

- N/A (event metadata change)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Wire field name matches web (`transformedTrafficURL`). EventMapper flattens metadata into v2 event `data`.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])