### PR TITLE
fix(events): include pageInstanceGuid on user interaction signals

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -630,6 +630,7 @@ internal class LayoutViewModel(
                 sessionId = experienceModel.sessionId,
                 parentGuid = parentGuid,
                 token = token,
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
                 objectData = mapOf(
                     KEY_USER_INTERACTION_ACTION to action.name,
                     KEY_USER_INTERACTION_CONTEXT to context.name,
@@ -804,6 +805,7 @@ internal class LayoutViewModel(
                 sessionId = experienceModel.sessionId,
                 parentGuid = pluginModel.instanceGuid,
                 token = pluginModel.token,
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
                 metadata = listOf(EventNameValue(KEY_INITIATOR, dismissReason)),
             ),
         )

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -1033,6 +1033,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
                         assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.objectData).isEqualTo(
                             mapOf(
                                 "action" to "OfferProgression",
@@ -1081,6 +1082,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
                         assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.objectData).isEqualTo(
                             mapOf(
                                 "action" to "ValidationTriggerFailed",
@@ -1115,6 +1117,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
                         assertThat(platformEvent.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.objectData).isEqualTo(
                             mapOf(
                                 "action" to "ToggleButtonStateTriggerClick",
@@ -1150,6 +1153,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
                         assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-1")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.objectData).isEqualTo(
                             mapOf(
                                 "action" to "ThumbnailClick",
@@ -1185,6 +1189,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalUserInteraction)
                         assertThat(platformEvent.parentGuid).isEqualTo("catalog-instance-guid-2")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.objectData).isEqualTo(
                             mapOf(
                                 "action" to "DropDownItemSelected",
@@ -1218,6 +1223,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anySatisfy { platformEvent ->
                         assertThat(platformEvent.eventType).isEqualTo(EventType.SignalInstantPurchaseDismissal)
                         assertThat(platformEvent.parentGuid).isEqualTo("pluginInstanceGuid")
+                        assertThat(platformEvent.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                         assertThat(platformEvent.metadata)
                             .anySatisfy { metadata ->
                                 assertThat(metadata.name).isEqualTo("initiator")


### PR DESCRIPTION
## Background

- `SignalUserInteraction` and `SignalInstantPurchaseDismissal` were emitted without `pageInstanceGuid`, so the Android SDK v2 wire payload omitted `page_instance_guid` while iOS includes it.

## What Has Changed

- Set `pageInstanceGuid` from `placementContext` on `SignalUserInteraction` (toggle, gallery, dropdown, validation, offer progression).
- Set `pageInstanceGuid` on `SignalInstantPurchaseDismissal`.
- Extended unit tests to assert `pageInstanceGuid` on those events.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- ForwardPayment `SignalCartItemInstantPurchaseInitiated` body shape parity is intentionally out of scope for this PR.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A