### PR TITLE
fix(events): include pageInstanceGuid on ForwardPayment initiated

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -487,6 +487,7 @@ internal class LayoutViewModel(
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItemProperties.instanceGuid(),
                 token = catalogItemProperties.token(),
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
                 eventData = catalogItemProperties.cartItemEventData(salePrice),
             ),
         )

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -340,6 +340,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                         assertThat(event.eventType).isEqualTo(EventType.SignalCartItemInstantPurchaseInitiated)
                         assertThat(event.parentGuid).isEqualTo("catalog-instance-guid-1")
                         assertThat(event.token).isEqualTo("catalog-token-1")
+                        assertThat(event.pageInstanceGuid).isEqualTo("pageInstanceGuid")
                     }
                 },
             )
@@ -707,6 +708,7 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
                     assertThat(events).anyMatch {
                         it.eventType == EventType.SignalCartItemInstantPurchaseInitiated &&
                             it.parentGuid == "catalog-instance-guid-1" &&
+                            it.pageInstanceGuid == "pageInstanceGuid" &&
                             it.eventData?.get("totalPrice") == "79.99" &&
                             it.eventData?.get("unitPrice") == "79.99"
                     }


### PR DESCRIPTION
## Background

- Confirm Order (`CartItemForwardPayment`) emitted `SignalCartItemInstantPurchaseInitiated` without `pageInstanceGuid`, so the SDK v2 wire omitted `page_instance_guid` while iOS includes it.

## What Has Changed

- Set `pageInstanceGuid` from `placementContext` on the ForwardPayment initiated platform event.
- Extended ForwardPayment unit tests to assert `pageInstanceGuid`.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Payload body shape (`eventData` vs lean `objectData`) is intentionally unchanged; that can follow separately if needed for object-data mapping parity.