### PR TITLE
fix(events): drop fat eventData from legacy InstantPurchase initiated

### DIFF
--- a/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
+++ b/roktux/src/main/java/com/rokt/roktux/viewmodel/layout/LayoutViewModel.kt
@@ -448,7 +448,7 @@ internal class LayoutViewModel(
                 sessionId = experienceModel.sessionId,
                 parentGuid = catalogItemProperties.instanceGuid(),
                 token = catalogItemProperties.token(),
-                eventData = catalogItemProperties.cartItemEventData(originalPrice),
+                pageInstanceGuid = experienceModel.placementContext.pageInstanceGuid,
             ),
         )
         setEvent(LayoutContract.LayoutEvent.CloseSelected(isDismissed = false))

--- a/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
+++ b/roktux/src/test/java/com/rokt/roktux/viewmodel/RoktLayoutViewModelTest.kt
@@ -321,6 +321,52 @@ class RoktLayoutViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `CartItemInstantPurchaseSelected sends lean initiated signal with ids and no event body`() = runTest {
+        // Arrange
+        clearMocks(uxEvent, platformEvent, viewStateChange)
+
+        // Act
+        layoutViewModel.setEvent(
+            LayoutContract.LayoutEvent.CartItemInstantPurchaseSelected(
+                catalogItemModel = createCatalogItemProperties(),
+            ),
+        )
+
+        // Assert — rich host UX callback unchanged
+        verify(timeout = 2000) {
+            uxEvent.invoke(
+                match { event ->
+                    event is RoktUxEvent.CartItemInstantPurchase &&
+                        event.layoutId == "pluginId" &&
+                        event.cartItemId == "cart-item-1" &&
+                        event.catalogItemId == "catalog-item-1" &&
+                        event.currency == "USD" &&
+                        event.description == "Lightweight daily shoes" &&
+                        event.linkedProductId == "linked-product-1" &&
+                        event.totalPrice == 99.99 &&
+                        event.unitPrice == 99.99 &&
+                        event.quantity == 1
+                },
+            )
+        }
+        // Assert — platform Initiated matches iOS: ids only, no fat eventData / objectData
+        verify(timeout = 2000) {
+            platformEvent.invoke(
+                match { events ->
+                    events.any {
+                        it.eventType == EventType.SignalCartItemInstantPurchaseInitiated &&
+                            it.parentGuid == "catalog-instance-guid-1" &&
+                            it.token == "catalog-token-1" &&
+                            it.pageInstanceGuid == "pageInstanceGuid" &&
+                            it.eventData == null &&
+                            it.objectData == null
+                    }
+                },
+            )
+        }
+    }
+
+    @Test
     fun `CartItemForwardPaymentSelected sends platform event carrying the catalog item token`() = runTest {
         // Arrange
         clearMocks(uxEvent, platformEvent, viewStateChange)


### PR DESCRIPTION
## Background

- Partner-managed Confirm Order emitted `SignalCartItemInstantPurchaseInitiated` with a fat cart-item `eventData` body and without `pageInstanceGuid`, while iOS sends ids only (`pageInstanceGuid` / parent / token) and an empty body.

## What Has Changed

- Set `pageInstanceGuid` on the legacy InstantPurchase initiated platform event.
- Stop sending fat `eventData` on that path; do not add lean `objectData`.
- Keep the rich `CartItemInstantPurchase` host UX callback unchanged.
- Add a unit test asserting ids plus null `eventData` / `objectData`.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- ForwardPayment still sends fat `eventData` (unchanged here); Device Pay already uses lean `objectData`.